### PR TITLE
[SITIONIX-1234] - Build unstable artifacts from PR branch

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -20,6 +20,10 @@ on:
         required: false
         type: number
         description: 'Issue or PR number (optional)'
+      ref:
+        required: false
+        type: string
+        default: ''
     secrets:
       APP_AFESOX:
         required: true
@@ -29,7 +33,14 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy (${{ inputs.name }} - ${{ inputs.execution }} - ${{ inputs.version }})
     steps:
-      - name: Checkout code
+      - name: Checkout code (target ref)
+        if: ${{ inputs.ref != '' }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Checkout code (default ref)
+        if: ${{ inputs.ref == '' }}
         uses: actions/checkout@v3
 
       - name: Set up JDK 17

--- a/.github/workflows/trigger-message.yml
+++ b/.github/workflows/trigger-message.yml
@@ -17,6 +17,7 @@ jobs:
       execution: ${{ steps.find-api-spec.outputs.api_spec_type }}
       ticket: ${{ steps.extract-ticket-num.outputs.ticket_num }}
       version: ${{ steps.read-definition-metadata.outputs.api_version }}
+      branch: ${{ steps.fetch-pr-branch.outputs.branch }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -24,6 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch and checkout pull request branch
+        id: fetch-pr-branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -32,6 +34,7 @@ jobs:
           echo "Pull request branch: $PR_BRANCH"
           git fetch origin $PR_BRANCH
           git checkout $PR_BRANCH
+          echo "branch=$PR_BRANCH" >> $GITHUB_OUTPUT
 
       - name: Post initial comment with workflow link
         id: post-initial-comment
@@ -121,6 +124,7 @@ jobs:
       version: ${{ needs.build.outputs.version }}
       execution: ${{ needs.build.outputs.execution }}
       variant: ${{ needs.build.outputs.ticket }}-unstable
+      ref: ${{ needs.build.outputs.branch }}
       issue_number: ${{ github.event.issue.number }}
     secrets:
       APP_AFESOX: ${{ secrets.APP_AFESOX }}


### PR DESCRIPTION
## Summary
- capture the pull request branch during the /generate workflow and expose it as a job output
- forward the branch to the reusable build-and-deploy workflow so the checkout uses the PR ref when available
- keep the develop workflow behavior unchanged by falling back to the default checkout when no ref is provided

## Testing
- not run (CI only changes)


------
https://chatgpt.com/codex/tasks/task_e_69088a58ddfc832eb65ce2cfe18a4559