### PR TITLE
[SITIONIX-123] - Retry org endpoint for package deletes

### DIFF
--- a/.github/workflows/delete-unstable-workflow.yml
+++ b/.github/workflows/delete-unstable-workflow.yml
@@ -56,6 +56,15 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             "/users/$PACKAGE_OWNER/packages/maven/$PACKAGE_NAME"
           STATUS=$?
+
+          if [ $STATUS -ne 0 ]; then
+            gh api \
+              --method DELETE \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "/orgs/$PACKAGE_OWNER/packages/maven/$PACKAGE_NAME"
+            STATUS=$?
+          fi
           set -e
           echo "::endgroup::"
 
@@ -70,6 +79,14 @@ jobs:
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             "/users/$PACKAGE_OWNER/packages/maven/$PACKAGE_NAME" 2>&1 || true)
+
+          if echo "$MESSAGE" | grep -q '404'; then
+            MESSAGE=$(gh api \
+              --method GET \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "/orgs/$PACKAGE_OWNER/packages/maven/$PACKAGE_NAME" 2>&1 || true)
+          fi
 
           if echo "$MESSAGE" | grep -q '404'; then
             echo "🔍 Package not found. Skipping delete."


### PR DESCRIPTION
## Summary
- restore the original delete step structure while keeping the repository owner output
- retry unstable package deletion against the organization endpoint if the user path fails
- preserve the existing 404 handling so workflows skip missing packages cleanly

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_6908937071e0832eb9e7ba63b298f18c