### PR TITLE
[SITIONIX-101] - Ensure comment builds use PR branch

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -16,6 +16,10 @@ on:
         required: false
         type: string
         default: stable
+      branch:
+        required: false
+        type: string
+        default: develop
       issue_number:
         required: false
         type: number
@@ -31,6 +35,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/trigger-message.yml
+++ b/.github/workflows/trigger-message.yml
@@ -17,6 +17,7 @@ jobs:
       execution: ${{ steps.find-api-spec.outputs.api_spec_type }}
       ticket: ${{ steps.extract-ticket-num.outputs.ticket_num }}
       version: ${{ steps.read-definition-metadata.outputs.api_version }}
+      branch: ${{ steps.fetch-pr-branch.outputs.branch }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -24,6 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch and checkout pull request branch
+        id: fetch-pr-branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -32,6 +34,7 @@ jobs:
           echo "Pull request branch: $PR_BRANCH"
           git fetch origin $PR_BRANCH
           git checkout $PR_BRANCH
+          echo "branch=$PR_BRANCH" >> $GITHUB_OUTPUT
 
       - name: Post initial comment with workflow link
         id: post-initial-comment
@@ -121,6 +124,7 @@ jobs:
       version: ${{ needs.build.outputs.version }}
       execution: ${{ needs.build.outputs.execution }}
       variant: ${{ needs.build.outputs.ticket }}-unstable
+      branch: ${{ needs.build.outputs.branch }}
       issue_number: ${{ github.event.issue.number }}
     secrets:
       APP_AFESOX: ${{ secrets.APP_AFESOX }}


### PR DESCRIPTION
## Summary
- allow the reusable build workflow to checkout a supplied branch, defaulting to develop
- capture the pull request branch when handling `/generate` commands and forward it to the build job

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_6908a669db20832e9889b4fc260db246