### PR TITLE
[SITIONIX-101] - Ensure generate flow checks out PR branch

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -16,6 +16,10 @@ on:
         required: false
         type: string
         default: stable
+      branch:
+        required: false
+        type: string
+        default: develop
       issue_number:
         required: false
         type: number
@@ -31,6 +35,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
+          fetch-depth: 0
+
+      - name: Display checkout details
+        run: |
+          echo "Checked out branch ref: ${{ inputs.branch }}"
+          git status -sb
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/trigger-message.yml
+++ b/.github/workflows/trigger-message.yml
@@ -17,21 +17,27 @@ jobs:
       execution: ${{ steps.find-api-spec.outputs.api_spec_type }}
       ticket: ${{ steps.extract-ticket-num.outputs.ticket_num }}
       version: ${{ steps.read-definition-metadata.outputs.api_version }}
+      branch: ${{ steps.determine-pr-branch.outputs.branch }}
     steps:
+      - name: Determine pull request branch
+        id: determine-pr-branch
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const issue_number = context.issue.number;
+            const { data: pr } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: issue_number
+            });
+            const branch = pr.head.ref;
+            core.info(`Pull request branch: ${branch}`);
+            core.setOutput('branch', branch);
+
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - name: Fetch and checkout pull request branch
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_NUMBER=${{ github.event.issue.number }}
-          PR_BRANCH=$(gh pr view $PR_NUMBER --json headRefName -q '.headRefName')
-          echo "Pull request branch: $PR_BRANCH"
-          git fetch origin $PR_BRANCH
-          git checkout $PR_BRANCH
+          ref: ${{ steps.determine-pr-branch.outputs.branch }}
 
       - name: Post initial comment with workflow link
         id: post-initial-comment
@@ -121,6 +127,7 @@ jobs:
       version: ${{ needs.build.outputs.version }}
       execution: ${{ needs.build.outputs.execution }}
       variant: ${{ needs.build.outputs.ticket }}-unstable
+      branch: ${{ needs.build.outputs.branch }}
       issue_number: ${{ github.event.issue.number }}
     secrets:
       APP_AFESOX: ${{ secrets.APP_AFESOX }}


### PR DESCRIPTION
## Summary
- resolve the PR branch via the GitHub API before any repository checkout in the generate workflow
- check out that branch for the generate workflow and propagate it to the reusable build job
- add diagnostics in the reusable build workflow to confirm the checked-out ref

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_6908a669db20832e9889b4fc260db246