### PR TITLE
[SITIONIX-76] - add create site contract and api-first workflow rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,13 @@
 # AGENTS
 
 BE service rules are located in `../AGENTS.md`.
+
+## PR Readiness Rules (API-first)
+
+- Every PR that changes a service contract in `apis/<service>/api-first/` must increment the service version versus `develop`.
+- The version in `apis/<service>/api-first/metadata.yml` (`api.version`) must match the version in `apis/<service>/api-first/openapi-rest.yml` (`info.version`).
+- PR title must use format `[SITIONIX-XX] - <short-description>`, where `XX` must match the branch ticket in `feature/SITIONIX-XX`.
+- After every push to a PR, trigger unstable generation for the required artifact type (`API` or `CLIENT`) using `/generate` with a valid name from `apis/metadata.yml`.
+- After unstable artifact is generated, update the dependent service to that unstable version and run its build to verify dependency resolution.
+- If Maven reuses cached artifacts, remove the exact local version from `~/.m2/repository/com/afesox/...` and rebuild to force fresh download.
+- Start implementation work only after unstable artifact generation and consumer build verification are successful.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,11 @@
 
 BE service rules are located in `../AGENTS.md`.
 
-## PR Readiness Rules (API-first)
+## API-first Pre-Implementation Rules
 
 - Every PR that changes a service contract in `apis/<service>/api-first/` must increment the service version versus `develop`.
 - The version in `apis/<service>/api-first/metadata.yml` (`api.version`) must match the version in `apis/<service>/api-first/openapi-rest.yml` (`info.version`).
-- PR title must use format `[SITIONIX-XX] - <short-description>`, where `XX` must match the branch ticket in `feature/SITIONIX-XX`.
 - After every push to a PR, trigger unstable generation for the required artifact type (`API` or `CLIENT`) using `/generate` with a valid name from `apis/metadata.yml`.
 - After unstable artifact is generated, update the dependent service to that unstable version and run its build to verify dependency resolution.
-- If Maven reuses cached artifacts, remove the exact local version from `~/.m2/repository/com/afesox/...` and rebuild to force fresh download.
+- If Maven reuses cached artifacts, remove the exact local version from `~/.m2/repository/com/afesox/...` and rebuild to force a fresh download.
 - Start implementation work only after unstable artifact generation and consumer build verification are successful.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,3 @@
 # AGENTS
 
 BE service rules are located in `../AGENTS.md`.
-
-## API-first Pre-Implementation Rules
-
-- Every PR that changes a service contract in `apis/<service>/api-first/` must increment the service version versus `develop`.
-- The version in `apis/<service>/api-first/metadata.yml` (`api.version`) must match the version in `apis/<service>/api-first/openapi-rest.yml` (`info.version`).
-- After every push to a PR, trigger unstable generation for the required artifact type (`API` or `CLIENT`) using `/generate` with a valid name from `apis/metadata.yml`.
-- After unstable artifact is generated, update the dependent service to that unstable version and run its build to verify dependency resolution.
-- If Maven reuses cached artifacts, remove the exact local version from `~/.m2/repository/com/afesox/...` and rebuild to force a fresh download.
-- Start implementation work only after unstable artifact generation and consumer build verification are successful.

--- a/apis/bffssox/api-first/metadata.yml
+++ b/apis/bffssox/api-first/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.9
+  version: 0.0.10
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/bffssox/api-first/openapi-rest.yml
+++ b/apis/bffssox/api-first/openapi-rest.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Backend for Frontend Sitionix
   description: API specification for the BFF authentication facade
-  version: 0.0.9
+  version: 0.0.10
   contact:
     name: APP Sitionix
 servers:
@@ -11,6 +11,7 @@ servers:
 tags:
   - name: Auth
   - name: User
+  - name: Site
 paths:
   /api/v1/auth/refresh:
     post:
@@ -132,6 +133,38 @@ paths:
                 $ref: '#/components/schemas/ResponseRegisterUserDTO'
         '400':
           $ref: '../../common/components.yml#/components/responses/BadRequest'
+        '500':
+          $ref: '../../common/components.yml#/components/responses/InternalServerError'
+  /api/v1/sites:
+    post:
+      tags:
+        - Site
+      operationId: createSite
+      summary: Create site
+      description: >
+        Creates a new site owned by the currently authenticated user.
+        The site is created with `DRAFT` status and must be opened by the client in builder using returned `siteId`.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSiteRequestDTO'
+      responses:
+        '201':
+          description: Site created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateSiteResponseDTO'
+        '400':
+          $ref: '../../common/components.yml#/components/responses/BadRequest'
+        '401':
+          $ref: '../../common/components.yml#/components/responses/Unauthorized'
+        '403':
+          $ref: '../../common/components.yml#/components/responses/Forbidden'
         '500':
           $ref: '../../common/components.yml#/components/responses/InternalServerError'
 
@@ -305,6 +338,74 @@ components:
               - ECOSYSTEM_OWNER
               - SITE_ADMIN
               - SITE_USER
+    CreateSiteRequestDTO:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 60
+          pattern: ".*\\S.*"
+          description: >
+            Human-readable site name. Value is trimmed before validation.
+            Duplicate names are allowed.
+          example: Portfolio
+        type:
+          type: string
+          enum:
+            - PORTFOLIO
+            - BUSINESS
+            - BLOG
+            - STORE
+            - LANDING
+            - OTHER
+          description: Logical site category used for onboarding and analytics.
+        description:
+          type: string
+          maxLength: 160
+          description: Short site description.
+        template:
+          type: string
+          default: BLANK
+          enum:
+            - BLANK
+          description: Initial template identifier used during site creation.
+    CreateSiteResponseDTO:
+      type: object
+      additionalProperties: false
+      required:
+        - siteId
+        - name
+        - status
+        - createdAt
+        - updatedAt
+      properties:
+        siteId:
+          type: string
+          format: uuid
+          description: Globally unique site identifier.
+        name:
+          type: string
+          description: Site name.
+        status:
+          type: string
+          description: Current site status.
+          enum:
+            - DRAFT
+            - PUBLISHED
+            - ARCHIVED
+          example: DRAFT
+        createdAt:
+          type: string
+          format: date-time
+          description: Site creation timestamp (UTC).
+        updatedAt:
+          type: string
+          format: date-time
+          description: Last site update timestamp (UTC).
     LoginRequestDTO:
       type: object
       required:


### PR DESCRIPTION
## Summary
- add BFF create-site API-first contract aligned with site-service flow
- add workflow readiness rules for /generate and unstable artifacts
- scope rules to service-specific AGENTS guidance

## Validation
- local checks only