### PR TITLE
[SITIONIX-80] - Add site meta event contracts

### DIFF
--- a/apis/metadata.yml
+++ b/apis/metadata.yml
@@ -20,11 +20,11 @@ apis:
   - name: EVENT SiteMeta STSSSOX Producer
     api-spec-type: event-producer
     definition-path: /stsssox/event
-    event-tag: Site Meta
+    event-tag: SiteMeta
   - name: EVENT SiteMeta STSSSOX Consumer
     api-spec-type: event-consumer
     definition-path: /stsssox/event
-    event-tag: Site Meta
+    event-tag: SiteMeta
   - name: EVENT NTFSSOX Producer
     api-spec-type: event-producer
     definition-path: /ntfssox/event

--- a/apis/metadata.yml
+++ b/apis/metadata.yml
@@ -17,6 +17,14 @@ apis:
   - name: CLIENT Site Service SOX
     api-spec-type: client
     definition-path: /stsssox/api-first
+  - name: EVENT SiteMeta STSSSOX Producer
+    api-spec-type: event-producer
+    definition-path: /stsssox/event
+    event-tag: Site Meta
+  - name: EVENT SiteMeta STSSSOX Consumer
+    api-spec-type: event-consumer
+    definition-path: /stsssox/event
+    event-tag: Site Meta
   - name: EVENT NTFSSOX Producer
     api-spec-type: event-producer
     definition-path: /ntfssox/event

--- a/apis/stsssox/event/asyncapi.yml
+++ b/apis/stsssox/event/asyncapi.yml
@@ -1,0 +1,50 @@
+asyncapi: 2.0.0
+info:
+  title: EVENT STSSSOX
+  version: 0.0.1
+  description: Events for STSSSOX
+
+defaultContentType: application/*+avro
+
+channels:
+  stsssox.${environment}.site-meta.public.unified.v1:
+    description: Site metadata topic for workspace read-model projection
+
+    publish:
+      summary: Publish site metadata event
+      operationId: publishSiteMetaEvent
+      tags:
+        - name: Site Meta
+      bindings:
+        kafka:
+          bindingVersion: 'latest'
+      x-itx-metadata-version: v1
+      x-itx-envelop-namespace: com.app_afesox.stsssox.events.sitemeta
+      x-itx-envelop-name: SiteMetaEnvelope
+      message:
+        $ref: '#/components/messages/SiteMetaEnvelope'
+
+    subscribe:
+      summary: Subscribe site metadata event
+      operationId: subscribeSiteMetaEvent
+      tags:
+        - name: Site Meta
+      bindings:
+        kafka:
+          bindingVersion: 'latest'
+      x-itx-metadata-version: v1
+      x-itx-envelop-namespace: com.app_afesox.stsssox.events.sitemeta
+      x-itx-envelop-name: SiteMetaEnvelope
+      message:
+        $ref: '#/components/messages/SiteMetaEnvelope'
+
+components:
+  messages:
+    SiteMetaEnvelope:
+      name: SiteMetaEnvelope
+      title: Site metadata envelope
+      summary: Site metadata envelope payload
+      contentType: application/*+avro
+      schemaFormat: application/vnd.apache.avro+json;version=1.0.0
+      payload:
+        $ref: "sitemeta/v1/site_meta_envelope.avsc"

--- a/apis/stsssox/event/asyncapi.yml
+++ b/apis/stsssox/event/asyncapi.yml
@@ -14,7 +14,7 @@ channels:
       summary: Publish site metadata event
       operationId: publishSiteMetaEvent
       tags:
-        - name: Site Meta
+        - name: SiteMeta
       bindings:
         kafka:
           bindingVersion: 'latest'
@@ -28,7 +28,7 @@ channels:
       summary: Subscribe site metadata event
       operationId: subscribeSiteMetaEvent
       tags:
-        - name: Site Meta
+        - name: SiteMeta
       bindings:
         kafka:
           bindingVersion: 'latest'

--- a/apis/stsssox/event/asyncapi.yml
+++ b/apis/stsssox/event/asyncapi.yml
@@ -7,7 +7,7 @@ info:
 defaultContentType: application/*+avro
 
 channels:
-  stsssox.${environment}.site-meta.public.unified.v1:
+  stsssox.${environment}.site-meta.public.v1:
     description: Site metadata topic for workspace read-model projection
 
     publish:

--- a/apis/stsssox/event/metadata.yml
+++ b/apis/stsssox/event/metadata.yml
@@ -1,0 +1,12 @@
+api:
+  version: 0.0.1
+  visibility: PUBLIC
+  metadata:
+    version: "1.0"
+  description: Site metadata event API
+  definition: asyncapi.yml
+  contact:
+    name: STSSSOX
+    email: stsssox@sitionix.com
+  type: application
+  wrapperPackage: com.app_afesox.stsssox.events

--- a/apis/stsssox/event/sitemeta/v1/events/01_site_created_event.avsc
+++ b/apis/stsssox/event/sitemeta/v1/events/01_site_created_event.avsc
@@ -1,0 +1,56 @@
+{
+  "type": "record",
+  "name": "SiteCreatedEvent",
+  "namespace": "com.app_afesox.stsssox.events.sitemeta",
+  "doc": "Site created payload for workspace read-model projection.",
+  "fields": [
+    {
+      "name": "siteId",
+      "type": "string",
+      "doc": "Site identifier (UUID)."
+    },
+    {
+      "name": "ownerUserId",
+      "type": "long",
+      "doc": "Owner user identifier from authentication context."
+    },
+    {
+      "name": "name",
+      "type": "string",
+      "doc": "Human-readable site name."
+    },
+    {
+      "name": "status",
+      "type": "SiteStatusDTO",
+      "doc": "Current site lifecycle status."
+    },
+    {
+      "name": "type",
+      "type": [
+        "null",
+        "SiteTypeDTO"
+      ],
+      "default": null,
+      "doc": "Optional site category."
+    },
+    {
+      "name": "description",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null,
+      "doc": "Optional site description."
+    },
+    {
+      "name": "createdAt",
+      "type": "string",
+      "doc": "Creation timestamp in UTC ISO-8601 format."
+    },
+    {
+      "name": "updatedAt",
+      "type": "string",
+      "doc": "Last update timestamp in UTC ISO-8601 format."
+    }
+  ]
+}

--- a/apis/stsssox/event/sitemeta/v1/events/01_site_created_event.avsc
+++ b/apis/stsssox/event/sitemeta/v1/events/01_site_created_event.avsc
@@ -10,9 +10,9 @@
       "doc": "Site identifier (UUID)."
     },
     {
-      "name": "ownerUserId",
+      "name": "userId",
       "type": "long",
-      "doc": "Owner user identifier from authentication context."
+      "doc": "User identifier from authentication context."
     },
     {
       "name": "name",

--- a/apis/stsssox/event/sitemeta/v1/events/01_site_meta_event.avsc
+++ b/apis/stsssox/event/sitemeta/v1/events/01_site_meta_event.avsc
@@ -1,0 +1,56 @@
+{
+  "type": "record",
+  "name": "SiteMetaEvent",
+  "namespace": "com.app_afesox.stsssox.events.sitemeta",
+  "doc": "Site metadata snapshot event used by workspace read-model projection.",
+  "fields": [
+    {
+      "name": "siteId",
+      "type": "string",
+      "doc": "Site identifier (UUID)."
+    },
+    {
+      "name": "ownerUserId",
+      "type": "long",
+      "doc": "Owner user identifier from authentication context."
+    },
+    {
+      "name": "name",
+      "type": "string",
+      "doc": "Human-readable site name."
+    },
+    {
+      "name": "status",
+      "type": "SiteStatusDTO",
+      "doc": "Current site lifecycle status."
+    },
+    {
+      "name": "type",
+      "type": [
+        "null",
+        "SiteTypeDTO"
+      ],
+      "default": null,
+      "doc": "Optional site category."
+    },
+    {
+      "name": "description",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null,
+      "doc": "Optional site description."
+    },
+    {
+      "name": "createdAt",
+      "type": "string",
+      "doc": "Creation timestamp in UTC ISO-8601 format."
+    },
+    {
+      "name": "updatedAt",
+      "type": "string",
+      "doc": "Last update timestamp in UTC ISO-8601 format."
+    }
+  ]
+}

--- a/apis/stsssox/event/sitemeta/v1/events/02_site_updated_event.avsc
+++ b/apis/stsssox/event/sitemeta/v1/events/02_site_updated_event.avsc
@@ -1,8 +1,8 @@
 {
   "type": "record",
-  "name": "SiteMetaEvent",
+  "name": "SiteUpdatedEvent",
   "namespace": "com.app_afesox.stsssox.events.sitemeta",
-  "doc": "Site metadata snapshot event used by workspace read-model projection.",
+  "doc": "Site updated payload for workspace read-model projection.",
   "fields": [
     {
       "name": "siteId",
@@ -16,13 +16,21 @@
     },
     {
       "name": "name",
-      "type": "string",
-      "doc": "Human-readable site name."
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null,
+      "doc": "Updated site name."
     },
     {
       "name": "status",
-      "type": "SiteStatusDTO",
-      "doc": "Current site lifecycle status."
+      "type": [
+        "null",
+        "SiteStatusDTO"
+      ],
+      "default": null,
+      "doc": "Updated site status."
     },
     {
       "name": "type",
@@ -31,7 +39,7 @@
         "SiteTypeDTO"
       ],
       "default": null,
-      "doc": "Optional site category."
+      "doc": "Updated site category."
     },
     {
       "name": "description",
@@ -40,17 +48,12 @@
         "string"
       ],
       "default": null,
-      "doc": "Optional site description."
-    },
-    {
-      "name": "createdAt",
-      "type": "string",
-      "doc": "Creation timestamp in UTC ISO-8601 format."
+      "doc": "Updated site description."
     },
     {
       "name": "updatedAt",
       "type": "string",
-      "doc": "Last update timestamp in UTC ISO-8601 format."
+      "doc": "Update timestamp in UTC ISO-8601 format."
     }
   ]
 }

--- a/apis/stsssox/event/sitemeta/v1/events/02_site_updated_event.avsc
+++ b/apis/stsssox/event/sitemeta/v1/events/02_site_updated_event.avsc
@@ -10,9 +10,9 @@
       "doc": "Site identifier (UUID)."
     },
     {
-      "name": "ownerUserId",
+      "name": "userId",
       "type": "long",
-      "doc": "Owner user identifier from authentication context."
+      "doc": "User identifier from authentication context."
     },
     {
       "name": "name",

--- a/apis/stsssox/event/sitemeta/v1/events/03_site_deleted_event.avsc
+++ b/apis/stsssox/event/sitemeta/v1/events/03_site_deleted_event.avsc
@@ -1,0 +1,23 @@
+{
+  "type": "record",
+  "name": "SiteDeletedEvent",
+  "namespace": "com.app_afesox.stsssox.events.sitemeta",
+  "doc": "Site deleted payload for workspace read-model projection.",
+  "fields": [
+    {
+      "name": "siteId",
+      "type": "string",
+      "doc": "Site identifier (UUID)."
+    },
+    {
+      "name": "ownerUserId",
+      "type": "long",
+      "doc": "Owner user identifier from authentication context."
+    },
+    {
+      "name": "deletedAt",
+      "type": "string",
+      "doc": "Deletion timestamp in UTC ISO-8601 format."
+    }
+  ]
+}

--- a/apis/stsssox/event/sitemeta/v1/events/03_site_deleted_event.avsc
+++ b/apis/stsssox/event/sitemeta/v1/events/03_site_deleted_event.avsc
@@ -10,9 +10,9 @@
       "doc": "Site identifier (UUID)."
     },
     {
-      "name": "ownerUserId",
+      "name": "userId",
       "type": "long",
-      "doc": "Owner user identifier from authentication context."
+      "doc": "User identifier from authentication context."
     },
     {
       "name": "deletedAt",

--- a/apis/stsssox/event/sitemeta/v1/imports/01_site_status.avsc
+++ b/apis/stsssox/event/sitemeta/v1/imports/01_site_status.avsc
@@ -1,0 +1,11 @@
+{
+  "type": "enum",
+  "name": "SiteStatusDTO",
+  "namespace": "com.app_afesox.stsssox.events.sitemeta",
+  "doc": "Site lifecycle status values.",
+  "symbols": [
+    "DRAFT",
+    "PUBLISHED",
+    "ARCHIVED"
+  ]
+}

--- a/apis/stsssox/event/sitemeta/v1/imports/02_site_type.avsc
+++ b/apis/stsssox/event/sitemeta/v1/imports/02_site_type.avsc
@@ -1,0 +1,14 @@
+{
+  "type": "enum",
+  "name": "SiteTypeDTO",
+  "namespace": "com.app_afesox.stsssox.events.sitemeta",
+  "doc": "Site category values.",
+  "symbols": [
+    "PORTFOLIO",
+    "BUSINESS",
+    "BLOG",
+    "STORE",
+    "LANDING",
+    "OTHER"
+  ]
+}

--- a/apis/stsssox/event/sitemeta/v1/site_meta_envelope.avsc
+++ b/apis/stsssox/event/sitemeta/v1/site_meta_envelope.avsc
@@ -9,7 +9,11 @@
     },
     {
       "name": "payload",
-      "type": "com.app_afesox.stsssox.events.sitemeta.SiteMetaEvent"
+      "type": [
+        "com.app_afesox.stsssox.events.sitemeta.SiteCreatedEvent",
+        "com.app_afesox.stsssox.events.sitemeta.SiteUpdatedEvent",
+        "com.app_afesox.stsssox.events.sitemeta.SiteDeletedEvent"
+      ]
     }
   ]
 }

--- a/apis/stsssox/event/sitemeta/v1/site_meta_envelope.avsc
+++ b/apis/stsssox/event/sitemeta/v1/site_meta_envelope.avsc
@@ -1,0 +1,15 @@
+{
+  "type": "record",
+  "name": "SiteMetaEnvelope",
+  "namespace": "com.app_afesox.stsssox.events.sitemeta",
+  "fields": [
+    {
+      "name": "metadata",
+      "type": "com.app_afesox.events.Metadata"
+    },
+    {
+      "name": "payload",
+      "type": "com.app_afesox.stsssox.events.sitemeta.SiteMetaEvent"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add STSSSOX Site Meta AsyncAPI contract
- add Avro envelope/payload schemas for site metadata projection
- register event producer/consumer entries in apis metadata

## Validation
- stage-avro-schemas.sh for stsssox/sitemeta
- generate-event-wrappers.sh for producer and consumer