### PR TITLE
[SITIONIX-99-4] - bump workspace api version for stable release

### DIFF
--- a/apis/wagssox/rest/metadata.yml
+++ b/apis/wagssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.3
+  version: 0.0.4
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/wagssox/rest/openapi.yml
+++ b/apis/wagssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Workspace Aggregation Service Sitionix
   description: API specification for workspace projection service
-  version: 0.0.3
+  version: 0.0.4
   contact:
     name: APP Sitionix
 servers:


### PR DESCRIPTION
Version bump for wagssox REST contract so develop workflow republishes stable api-first and client artifacts after the rest-layout migration.