### PR TITLE
[SITIONIX-105-7] - fix common error refs for bff api

### DIFF
--- a/apis/bffssox/rest/metadata.yml
+++ b/apis/bffssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.17
+  version: 0.0.18
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/bffssox/rest/openapi.yml
+++ b/apis/bffssox/rest/openapi.yml
@@ -77,21 +77,21 @@ components:
     LoginResponseDTO:
       $ref: './schemas/v1/auth/login-response-dto.yml#/LoginResponseDTO'
     ErrorDTO:
-      $ref: '../../common/rest/openapi.yml#/components/schemas/ErrorDTO'
+      $ref: '../../common/rest/error/error-dto.yml#/ErrorDTO'
   responses:
     BadRequest:
-      $ref: '../../common/rest/openapi.yml#/components/responses/BadRequest'
+      $ref: '../../common/rest/error/responses.yml#/BadRequest'
     NotFound:
-      $ref: '../../common/rest/openapi.yml#/components/responses/NotFound'
+      $ref: '../../common/rest/error/responses.yml#/NotFound'
     Conflict:
-      $ref: '../../common/rest/openapi.yml#/components/responses/Conflict'
+      $ref: '../../common/rest/error/responses.yml#/Conflict'
     Gone:
-      $ref: '../../common/rest/openapi.yml#/components/responses/Gone'
+      $ref: '../../common/rest/error/responses.yml#/Gone'
     InternalServerError:
-      $ref: '../../common/rest/openapi.yml#/components/responses/InternalServerError'
+      $ref: '../../common/rest/error/responses.yml#/InternalServerError'
     Unauthorized:
-      $ref: '../../common/rest/openapi.yml#/components/responses/Unauthorized'
+      $ref: '../../common/rest/error/responses.yml#/Unauthorized'
     Forbidden:
-      $ref: '../../common/rest/openapi.yml#/components/responses/Forbidden'
+      $ref: '../../common/rest/error/responses.yml#/Forbidden'
     TooManyRequests:
-      $ref: '../../common/rest/openapi.yml#/components/responses/TooManyRequests'
+      $ref: '../../common/rest/error/responses.yml#/TooManyRequests'

--- a/apis/bffssox/rest/openapi.yml
+++ b/apis/bffssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Backend for Frontend Sitionix
   description: API specification for the BFF authentication facade
-  version: 0.0.17
+  version: 0.0.18
   contact:
     name: APP Sitionix
 servers:


### PR DESCRIPTION
## Summary
- replace bffssox common error references to point directly at apis/common/rest/error files
- remove the temporary dependency on common/rest/openapi.yml for this surface
- keep this PR scoped to the bffssox REST surface only
