### PR TITLE
[SITIONIX-105-8] - fix common error refs for automation api

### DIFF
--- a/apis/atmssox/rest/metadata.yml
+++ b/apis/atmssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.2
+  version: 0.0.3
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/atmssox/rest/openapi.yml
+++ b/apis/atmssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Automation Service Sitionix
   description: API specification for automation service
-  version: 0.0.2
+  version: 0.0.3
   contact:
     name: APP Sitionix
 servers:

--- a/apis/atmssox/rest/openapi.yml
+++ b/apis/atmssox/rest/openapi.yml
@@ -30,21 +30,21 @@ components:
     AgentsResponseDTO:
       $ref: './schemas/v1/agent/agents-response-dto.yml#/AgentsResponse'
     ErrorDTO:
-      $ref: '../../common/rest/openapi.yml#/components/schemas/ErrorDTO'
+      $ref: '../../common/rest/error/error-dto.yml#/ErrorDTO'
   responses:
     BadRequest:
-      $ref: '../../common/rest/openapi.yml#/components/responses/BadRequest'
+      $ref: '../../common/rest/error/responses.yml#/BadRequest'
     NotFound:
-      $ref: '../../common/rest/openapi.yml#/components/responses/NotFound'
+      $ref: '../../common/rest/error/responses.yml#/NotFound'
     Conflict:
-      $ref: '../../common/rest/openapi.yml#/components/responses/Conflict'
+      $ref: '../../common/rest/error/responses.yml#/Conflict'
     Gone:
-      $ref: '../../common/rest/openapi.yml#/components/responses/Gone'
+      $ref: '../../common/rest/error/responses.yml#/Gone'
     InternalServerError:
-      $ref: '../../common/rest/openapi.yml#/components/responses/InternalServerError'
+      $ref: '../../common/rest/error/responses.yml#/InternalServerError'
     Unauthorized:
-      $ref: '../../common/rest/openapi.yml#/components/responses/Unauthorized'
+      $ref: '../../common/rest/error/responses.yml#/Unauthorized'
     Forbidden:
-      $ref: '../../common/rest/openapi.yml#/components/responses/Forbidden'
+      $ref: '../../common/rest/error/responses.yml#/Forbidden'
     TooManyRequests:
-      $ref: '../../common/rest/openapi.yml#/components/responses/TooManyRequests'
+      $ref: '../../common/rest/error/responses.yml#/TooManyRequests'


### PR DESCRIPTION
## Summary
- replace atmssox common error references to point directly at apis/common/rest/error files
- remove the temporary dependency on common/rest/openapi.yml for this surface
- keep this PR scoped to the atmssox REST surface only
