### PR TITLE
[SITIONIX-105] - align atmssox DTO schema names

### DIFF
--- a/apis/atmssox/rest/metadata.yml
+++ b/apis/atmssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.3
+  version: 0.0.4
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/atmssox/rest/openapi.yml
+++ b/apis/atmssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Automation Service Sitionix
   description: API specification for automation service
-  version: 0.0.3
+  version: 0.0.4
   contact:
     name: APP Sitionix
 servers:

--- a/apis/atmssox/rest/openapi.yml
+++ b/apis/atmssox/rest/openapi.yml
@@ -24,11 +24,11 @@ components:
       description: Service-to-service access token (Bearer).
   schemas:
     CreateAgentRequestDTO:
-      $ref: './schemas/v1/agent/create-agent-request-dto.yml#/CreateAgentRequest'
+      $ref: './schemas/v1/agent/create-agent-request-dto.yml#/CreateAgentRequestDTO'
     AgentDTO:
-      $ref: './schemas/v1/agent/agent-dto.yml#/Agent'
+      $ref: './schemas/v1/agent/agent-dto.yml#/AgentDTO'
     AgentsResponseDTO:
-      $ref: './schemas/v1/agent/agents-response-dto.yml#/AgentsResponse'
+      $ref: './schemas/v1/agent/agents-response-dto.yml#/AgentsResponseDTO'
     ErrorDTO:
       $ref: '../../common/rest/error/error-dto.yml#/ErrorDTO'
   responses:

--- a/apis/atmssox/rest/schemas/v1/agent/agent-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/agent-dto.yml
@@ -1,5 +1,5 @@
-Agent:
-  title: Agent
+AgentDTO:
+  title: AgentDTO
   type: object
   additionalProperties: false
   required:

--- a/apis/atmssox/rest/schemas/v1/agent/agents-response-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/agents-response-dto.yml
@@ -1,5 +1,5 @@
-AgentsResponse:
-  title: AgentsResponse
+AgentsResponseDTO:
+  title: AgentsResponseDTO
   type: object
   additionalProperties: false
   required:

--- a/apis/atmssox/rest/schemas/v1/agent/create-agent-request-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/create-agent-request-dto.yml
@@ -1,5 +1,5 @@
-CreateAgentRequest:
-  title: CreateAgentRequest
+CreateAgentRequestDTO:
+  title: CreateAgentRequestDTO
   type: object
   additionalProperties: false
   required:


### PR DESCRIPTION
## Summary
- align ATMSSOX schema object names to DTO pattern
- update schema keys/titles to CreateAgentRequestDTO, AgentDTO, AgentsResponseDTO
- update OpenAPI component refs to new DTO schema anchors