### PR TITLE
[SITIONIX-105] - add DTO suffix for bffssox agent schemas

### DIFF
--- a/apis/bffssox/rest/metadata.yml
+++ b/apis/bffssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.18
+  version: 0.0.19
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/bffssox/rest/openapi.yml
+++ b/apis/bffssox/rest/openapi.yml
@@ -61,11 +61,11 @@ components:
     CreateSiteResponseDTO:
       $ref: './schemas/v1/site/create-site-response-dto.yml#/CreateSiteResponseDTO'
     CreateAgentRequestDTO:
-      $ref: './schemas/v1/agent/create-agent-request-dto.yml#/CreateAgentRequest'
+      $ref: './schemas/v1/agent/create-agent-request-dto.yml#/CreateAgentRequestDTO'
     AgentDTO:
-      $ref: './schemas/v1/agent/agent-dto.yml#/Agent'
+      $ref: './schemas/v1/agent/agent-dto.yml#/AgentDTO'
     AgentsResponseDTO:
-      $ref: './schemas/v1/agent/agents-response-dto.yml#/AgentsResponse'
+      $ref: './schemas/v1/agent/agents-response-dto.yml#/AgentsResponseDTO'
     WorkspaceSitesResponseDTO:
       $ref: './schemas/v1/site/workspace-sites-response-dto.yml#/WorkspaceSitesResponseDTO'
     SiteOverviewDTO:

--- a/apis/bffssox/rest/openapi.yml
+++ b/apis/bffssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Backend for Frontend Sitionix
   description: API specification for the BFF authentication facade
-  version: 0.0.18
+  version: 0.0.19
   contact:
     name: APP Sitionix
 servers:

--- a/apis/bffssox/rest/schemas/v1/agent/agent-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agent-dto.yml
@@ -1,5 +1,5 @@
-Agent:
-  title: Agent
+AgentDTO:
+  title: AgentDTO
   type: object
   additionalProperties: false
   required:

--- a/apis/bffssox/rest/schemas/v1/agent/agents-response-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agents-response-dto.yml
@@ -1,5 +1,5 @@
-AgentsResponse:
-  title: AgentsResponse
+AgentsResponseDTO:
+  title: AgentsResponseDTO
   type: object
   additionalProperties: false
   required:

--- a/apis/bffssox/rest/schemas/v1/agent/create-agent-request-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/create-agent-request-dto.yml
@@ -1,5 +1,5 @@
-CreateAgentRequest:
-  title: CreateAgentRequest
+CreateAgentRequestDTO:
+  title: CreateAgentRequestDTO
   type: object
   additionalProperties: false
   required:


### PR DESCRIPTION
What changed: renamed bffssox agent schemas and refs to DTO-suffixed names (AgentDTO, CreateAgentRequestDTO, AgentsResponseDTO). Why: generated api-first models must keep DTO suffix for consumers.