### PR TITLE
[SITIONIX-110] - align frontend unstable cleanup and stable publish flow

### DIFF
--- a/.github/workflows/delete-unstable-frontend-contract-workflow.yml
+++ b/.github/workflows/delete-unstable-frontend-contract-workflow.yml
@@ -1,0 +1,119 @@
+name: Delete Unstable Frontend Contract Workflow
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        required: true
+        type: string
+      execution:
+        required: true
+        type: string
+      ticket:
+        required: true
+        type: string
+      issue_number:
+        required: false
+        type: number
+    secrets:
+      APP_AFESOX:
+        required: true
+
+jobs:
+  delete:
+    name: Delete Unstable Frontend Package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build npm package name from inputs
+        if: endsWith(inputs.ticket, '-unstable')
+        id: build-package-name
+        run: |
+          PACKAGE_NAME="@sitionix/app-afesox-${{ inputs.name }}-${{ inputs.execution }}-${{ inputs.ticket }}"
+          echo "package_name=$PACKAGE_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve package owner from context
+        if: endsWith(inputs.ticket, '-unstable')
+        id: resolve-owner
+        run: echo "owner=${{ github.repository_owner }}" >> "$GITHUB_OUTPUT"
+
+      - name: Delete npm package via GitHub API
+        if: endsWith(inputs.ticket, '-unstable')
+        env:
+          GH_TOKEN: ${{ secrets.APP_AFESOX }}
+          PACKAGE_NAME: ${{ steps.build-package-name.outputs.package_name }}
+          PACKAGE_OWNER: ${{ steps.resolve-owner.outputs.owner }}
+        run: |
+          set -euo pipefail
+          ENCODED_NAME="$(python3 -c 'import urllib.parse, os; print(urllib.parse.quote(os.environ["PACKAGE_NAME"], safe=""))')"
+
+          echo "Deleting npm package: $PACKAGE_NAME"
+          set +e
+          gh api \
+            --method DELETE \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "/user/packages/npm/$ENCODED_NAME"
+          STATUS=$?
+
+          if [ $STATUS -ne 0 ]; then
+            gh api \
+              --method DELETE \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "/orgs/$PACKAGE_OWNER/packages/npm/$ENCODED_NAME"
+            STATUS=$?
+          fi
+          set -e
+
+          if [ $STATUS -eq 0 ]; then
+            echo "Successfully deleted unstable npm package."
+            exit 0
+          fi
+
+          echo "Delete failed. Checking existence to tolerate missing package."
+          USER_GET="$(gh api --method GET -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" "/user/packages/npm/$ENCODED_NAME" 2>&1 || true)"
+          if echo "$USER_GET" | grep -q '404'; then
+            ORG_GET="$(gh api --method GET -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" "/orgs/$PACKAGE_OWNER/packages/npm/$ENCODED_NAME" 2>&1 || true)"
+            if echo "$ORG_GET" | grep -q '404'; then
+              echo "Package not found; nothing to delete."
+              exit 0
+            fi
+          fi
+
+          echo "GitHub API delete failed with status $STATUS"
+          exit $STATUS
+
+  notify-failure:
+    name: Delete frontend package failure comment
+    if: failure()
+    needs: delete
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post comment to PR
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const issue_number = ${{ inputs.issue_number }};
+            if (!issue_number) {
+              console.log('No issue number provided, skipping comment.');
+              return;
+            }
+            const run_id = process.env.GITHUB_RUN_ID;
+            const repo = context.repo;
+            const workflow_run_url = `https://github.com/${repo.owner}/${repo.repo}/actions/runs/${run_id}`;
+
+            const body = [
+              '---',
+              '### ❌ Frontend Unstable Delete Job Failed',
+              '',
+              '> ⚠️ **The frontend unstable package delete job could not be completed.**',
+              '',
+              `🔍 [View Workflow Run Logs](${workflow_run_url})`,
+              '---'
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              ...repo,
+              issue_number,
+              body
+            });

--- a/.github/workflows/delete-unused-unstable-versions.yml
+++ b/.github/workflows/delete-unused-unstable-versions.yml
@@ -58,3 +58,17 @@ jobs:
       issue_number: ${{ github.event.pull_request.number }}
     secrets:
       APP_AFESOX: ${{ secrets.APP_AFESOX }}
+
+  delete-unused-frontend-contract-version:
+    needs: [detect, parse-ticket]
+    if: ${{ needs.detect.outputs.changed_frontend_contract == 'true' }}
+    uses: ./.github/workflows/delete-unstable-frontend-contract-workflow.yml
+    strategy:
+      matrix: ${{ fromJson(needs.detect.outputs.matrix_frontend_contract) }}
+    with:
+      name: ${{ matrix.name }}
+      execution: ${{ matrix.execution }}
+      ticket: ${{ needs.parse-ticket.outputs.ticket }}
+      issue_number: ${{ github.event.pull_request.number }}
+    secrets:
+      APP_AFESOX: ${{ secrets.APP_AFESOX }}

--- a/.github/workflows/detect-metadata-changes.yml
+++ b/.github/workflows/detect-metadata-changes.yml
@@ -149,17 +149,22 @@ jobs:
 
               VERSION="$(yq_val '.api.version' "$FILE")"
               NAME="$(yq_val '.api.name' "$FILE")"
+              DEFINITION_PATH="/$(echo "$FILE" | awk -F/ '{print $2}')/rest"
 
-              # executions as lines; empty means invalid
-              EXECUTIONS="$(yq e -r '.api.executions[].type // ""' "$FILE" 2>/dev/null || true)"
+              # Resolve executions from central registry (apis/metadata.yml) by definition-path.
+              # This keeps unstable and develop flows aligned and avoids duplicated execution config.
+              EXECUTIONS="$(yq e -r ".apis[] | select(.definition-path == \"${DEFINITION_PATH}\") | .api-spec-type" apis/metadata.yml 2>/dev/null || true)"
 
               if [[ -z "$VERSION" || -z "$NAME" || -z "$EXECUTIONS" ]]; then
-                echo "::error:: Invalid REST API metadata file: $FILE (api.version/api.name/api.executions[].type required)"
+                echo "::error:: Invalid REST API metadata file or missing central execution mapping: $FILE (api.version/api.name and apis/metadata.yml mapping required)"
                 exit 1
               fi
 
               while IFS= read -r EXEC; do
                 [[ -z "$EXEC" ]] && continue
+                if [[ "$EXEC" =~ ^event- ]]; then
+                  continue
+                fi
                 if [[ "$EXEC" == "frontend" ]]; then
                   FRONTEND_CONTRACT_CHANGED_FLAG=true
                 fi

--- a/apis/bffssox/rest/metadata.yml
+++ b/apis/bffssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.19
+  version: 0.0.20
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/bffssox/rest/openapi.yml
+++ b/apis/bffssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Backend for Frontend Sitionix
   description: API specification for the BFF authentication facade
-  version: 0.0.19
+  version: 0.0.20
   contact:
     name: APP Sitionix
 servers:


### PR DESCRIPTION
## Summary
- align develop detection with central `apis/metadata.yml` execution mapping
- add frontend unstable package cleanup workflow for merge-to-develop path
- wire frontend unstable cleanup into delete-unused-unstable-versions flow

## Why
- keep generation behavior dynamic and consistent between PR comment unstable and develop stable flows
- ensure merge to develop removes matching unstable frontend package and publishes stable package
