### PR TITLE
[SITIONIX-112] - add patch agent identity contracts

### DIFF
--- a/apis/atmssox/rest/metadata.yml
+++ b/apis/atmssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.4
+  version: 0.0.5
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/atmssox/rest/openapi.yml
+++ b/apis/atmssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Automation Service Sitionix
   description: API specification for automation service
-  version: 0.0.4
+  version: 0.0.5
   contact:
     name: APP Sitionix
 servers:
@@ -25,6 +25,8 @@ components:
   schemas:
     CreateAgentRequestDTO:
       $ref: './schemas/v1/agent/create-agent-request-dto.yml#/CreateAgentRequestDTO'
+    PatchAgentRequestDTO:
+      $ref: './schemas/v1/agent/patch-agent-request-dto.yml#/PatchAgentRequestDTO'
     AgentDTO:
       $ref: './schemas/v1/agent/agent-dto.yml#/AgentDTO'
     AgentsResponseDTO:

--- a/apis/atmssox/rest/paths/v1/agents-by-id.yml
+++ b/apis/atmssox/rest/paths/v1/agents-by-id.yml
@@ -31,3 +31,43 @@ get:
       $ref: '../../openapi.yml#/components/responses/NotFound'
     '500':
       $ref: '../../openapi.yml#/components/responses/InternalServerError'
+patch:
+  tags:
+    - Agent
+  operationId: patchAgent
+  summary: Patch agent identity
+  description: >
+    Partially updates one automation agent by identifier.
+    Supports only `name` and `description` fields.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: agentId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/PatchAgentRequestDTO'
+  responses:
+    '200':
+      description: Updated agent
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/AgentDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/atmssox/rest/schemas/v1/agent/patch-agent-request-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/patch-agent-request-dto.yml
@@ -1,0 +1,24 @@
+PatchAgentRequestDTO:
+  title: PatchAgentRequestDTO
+  type: object
+  additionalProperties: false
+  anyOf:
+    - required:
+        - name
+    - required:
+        - description
+  properties:
+    name:
+      type: string
+      minLength: 1
+      maxLength: 60
+      pattern: ".*\\S.*"
+      description: Human-readable agent name. Value is trimmed before validation.
+      example: Updated Product Manager
+    description:
+      type: string
+      minLength: 1
+      maxLength: 160
+      pattern: ".*\\S.*"
+      description: Short description of the agent responsibility.
+      example: Updated description

--- a/apis/bffssox/rest/metadata.yml
+++ b/apis/bffssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.21
+  version: 0.0.22
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/bffssox/rest/openapi.yml
+++ b/apis/bffssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Backend for Frontend Sitionix
   description: API specification for the BFF authentication facade
-  version: 0.0.21
+  version: 0.0.22
   contact:
     name: APP Sitionix
 servers:
@@ -62,6 +62,8 @@ components:
       $ref: './schemas/v1/site/create-site-response-dto.yml#/CreateSiteResponseDTO'
     CreateAgentRequestDTO:
       $ref: './schemas/v1/agent/create-agent-request-dto.yml#/CreateAgentRequestDTO'
+    PatchAgentRequestDTO:
+      $ref: './schemas/v1/agent/patch-agent-request-dto.yml#/PatchAgentRequestDTO'
     AgentDTO:
       $ref: './schemas/v1/agent/agent-dto.yml#/AgentDTO'
     AgentsResponseDTO:

--- a/apis/bffssox/rest/paths/v1/agents-by-id.yml
+++ b/apis/bffssox/rest/paths/v1/agents-by-id.yml
@@ -31,3 +31,43 @@ get:
       $ref: '../../openapi.yml#/components/responses/NotFound'
     '500':
       $ref: '../../openapi.yml#/components/responses/InternalServerError'
+patch:
+  tags:
+    - Agent
+  operationId: patchAgent
+  summary: Patch automation agent identity
+  description: >
+    Partially updates one automation agent for the authenticated user.
+    Supports only `name` and `description` fields.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: agentId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/PatchAgentRequestDTO'
+  responses:
+    '200':
+      description: Updated agent
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/AgentDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/bffssox/rest/schemas/v1/agent/patch-agent-request-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/patch-agent-request-dto.yml
@@ -1,0 +1,24 @@
+PatchAgentRequestDTO:
+  title: PatchAgentRequestDTO
+  type: object
+  additionalProperties: false
+  anyOf:
+    - required:
+        - name
+    - required:
+        - description
+  properties:
+    name:
+      type: string
+      minLength: 1
+      maxLength: 60
+      pattern: ".*\\S.*"
+      description: Human-readable agent name. Value is trimmed before validation.
+      example: Updated Product Manager
+    description:
+      type: string
+      minLength: 1
+      maxLength: 160
+      pattern: ".*\\S.*"
+      description: Short description of the agent responsibility.
+      example: Updated description


### PR DESCRIPTION
## Summary
- add PATCH /api/v1/agents/{agentId} for atmssox and bffssox contracts
- add typed PatchAgentRequestDTO with optional name/description and at-least-one semantics
- bump atmssox and bffssox rest versions

## Scope
- atmssox/rest
- bffssox/rest