### PR TITLE
[SITIONIX-113] - add agent lifecycle contracts

### DIFF
--- a/apis/atmssox/rest/metadata.yml
+++ b/apis/atmssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.5
+  version: 0.0.6
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/atmssox/rest/openapi.yml
+++ b/apis/atmssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Automation Service Sitionix
   description: API specification for automation service
-  version: 0.0.5
+  version: 0.0.6
   contact:
     name: APP Sitionix
 servers:
@@ -15,6 +15,10 @@ paths:
     $ref: './paths/v1/agents.yml'
   /api/v1/agents/{agentId}:
     $ref: './paths/v1/agents-by-id.yml'
+  /api/v1/agents/{agentId}/activate:
+    $ref: './paths/v1/agents-activate.yml'
+  /api/v1/agents/{agentId}/archive:
+    $ref: './paths/v1/agents-archive.yml'
 components:
   securitySchemes:
     bearerAuth:

--- a/apis/atmssox/rest/paths/v1/agents-activate.yml
+++ b/apis/atmssox/rest/paths/v1/agents-activate.yml
@@ -1,0 +1,34 @@
+post:
+  tags:
+    - Agent
+  operationId: activateAgent
+  summary: Activate agent
+  description: >
+    Activates one automation agent by identifier.
+    Allowed transition for this version: `DRAFT -> ACTIVE`.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: agentId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    '200':
+      description: Updated agent
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/AgentDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/atmssox/rest/paths/v1/agents-archive.yml
+++ b/apis/atmssox/rest/paths/v1/agents-archive.yml
@@ -1,0 +1,34 @@
+post:
+  tags:
+    - Agent
+  operationId: archiveAgent
+  summary: Archive agent
+  description: >
+    Archives one automation agent by identifier.
+    Allowed transition for this version: `ACTIVE -> ARCHIVED`.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: agentId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    '200':
+      description: Updated agent
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/AgentDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/atmssox/rest/schemas/v1/agent/agent-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/agent-dto.yml
@@ -25,7 +25,9 @@ AgentDTO:
       description: Current agent status.
       enum:
         - DRAFT
-      example: DRAFT
+        - ACTIVE
+        - ARCHIVED
+      example: ACTIVE
     createdAt:
       type: string
       format: date-time

--- a/apis/bffssox/rest/metadata.yml
+++ b/apis/bffssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.22
+  version: 0.0.23
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/bffssox/rest/openapi.yml
+++ b/apis/bffssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Backend for Frontend Sitionix
   description: API specification for the BFF authentication facade
-  version: 0.0.22
+  version: 0.0.23
   contact:
     name: APP Sitionix
 servers:
@@ -30,6 +30,10 @@ paths:
     $ref: './paths/v1/agents.yml'
   /api/v1/agents/{agentId}:
     $ref: './paths/v1/agents-by-id.yml'
+  /api/v1/agents/{agentId}/activate:
+    $ref: './paths/v1/agents-activate.yml'
+  /api/v1/agents/{agentId}/archive:
+    $ref: './paths/v1/agents-archive.yml'
   /api/v1/auth/login:
     $ref: './paths/v1/auth-login.yml'
 components:

--- a/apis/bffssox/rest/paths/v1/agents-activate.yml
+++ b/apis/bffssox/rest/paths/v1/agents-activate.yml
@@ -1,0 +1,34 @@
+post:
+  tags:
+    - Agent
+  operationId: activateAgent
+  summary: Activate automation agent
+  description: >
+    Activates one automation agent for the authenticated user.
+    Allowed transition for this version: `DRAFT -> ACTIVE`.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: agentId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    '200':
+      description: Updated agent
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/AgentDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/bffssox/rest/paths/v1/agents-archive.yml
+++ b/apis/bffssox/rest/paths/v1/agents-archive.yml
@@ -1,0 +1,34 @@
+post:
+  tags:
+    - Agent
+  operationId: archiveAgent
+  summary: Archive automation agent
+  description: >
+    Archives one automation agent for the authenticated user.
+    Allowed transition for this version: `ACTIVE -> ARCHIVED`.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: agentId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    '200':
+      description: Updated agent
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/AgentDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/bffssox/rest/schemas/v1/agent/agent-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agent-dto.yml
@@ -25,7 +25,9 @@ AgentDTO:
       description: Current agent status.
       enum:
         - DRAFT
-      example: DRAFT
+        - ACTIVE
+        - ARCHIVED
+      example: ACTIVE
     createdAt:
       type: string
       format: date-time


### PR DESCRIPTION
## Summary
- add activate/archive endpoints for atmssox and bffssox
- extend Agent status enum to DRAFT/ACTIVE/ARCHIVED in both contract surfaces
- bump REST versions (atmssox 0.0.6, bffssox 0.0.23)

## Why
Implements explicit lifecycle action contract for agent status transitions.