### PR TITLE
[SITIONIX-118] - add agent rules rest contracts

### DIFF
--- a/apis/atmssox/rest/metadata.yml
+++ b/apis/atmssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.10
+  version: 0.0.11
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/atmssox/rest/openapi.yml
+++ b/apis/atmssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Automation Service Sitionix
   description: API specification for automation service
-  version: 0.0.10
+  version: 0.0.11
   contact:
     name: APP Sitionix
 servers:
@@ -23,6 +23,10 @@ paths:
     $ref: './paths/v1/agents-restore.yml'
   /api/v1/agents/{agentId}/chat:
     $ref: './paths/v1/agents-chat.yml'
+  /api/v1/agents/{agentId}/rules:
+    $ref: './paths/v1/agents-rules.yml'
+  /api/v1/agents/{agentId}/rules/{ruleId}:
+    $ref: './paths/v1/agents-rules-by-id.yml'
   /api/v1/agents/{agentId}/conversations:
     $ref: './paths/v1/agents-conversations.yml'
   /api/v1/conversations/{conversationId}:
@@ -55,6 +59,16 @@ components:
       $ref: './schemas/v1/agent/agent-conversations-response-dto.yml#/AgentConversationsResponseDTO'
     AgentConversationDetailsDTO:
       $ref: './schemas/v1/agent/agent-conversation-details-dto.yml#/AgentConversationDetailsDTO'
+    AgentRuleDTO:
+      $ref: './schemas/v1/agent/agent-rule-dto.yml#/AgentRuleDTO'
+    AgentRulesResponseDTO:
+      $ref: './schemas/v1/agent/agent-rules-response-dto.yml#/AgentRulesResponseDTO'
+    CreateAgentRuleRequestDTO:
+      $ref: './schemas/v1/agent/create-agent-rule-request-dto.yml#/CreateAgentRuleRequestDTO'
+    PatchAgentRuleRequestDTO:
+      $ref: './schemas/v1/agent/patch-agent-rule-request-dto.yml#/PatchAgentRuleRequestDTO'
+    DeleteAgentRuleResponseDTO:
+      $ref: './schemas/v1/agent/delete-agent-rule-response-dto.yml#/DeleteAgentRuleResponseDTO'
     ErrorDTO:
       $ref: '../../common/rest/error/error-dto.yml#/ErrorDTO'
   responses:

--- a/apis/atmssox/rest/paths/v1/agents-rules-by-id.yml
+++ b/apis/atmssox/rest/paths/v1/agents-rules-by-id.yml
@@ -1,0 +1,88 @@
+patch:
+  tags:
+    - Agent
+  operationId: patchAgentRule
+  summary: Update active automation rule
+  description: >
+    Updates text of one active rule for one automation agent owned by the authenticated user.
+    Deleted rules are rejected in this flow.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: agentId
+      required: true
+      schema:
+        type: string
+        format: uuid
+    - in: path
+      name: ruleId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/PatchAgentRuleRequestDTO'
+  responses:
+    '200':
+      description: Updated rule
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/AgentRuleDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '409':
+      $ref: '../../openapi.yml#/components/responses/Conflict'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'
+delete:
+  tags:
+    - Agent
+  operationId: deleteAgentRule
+  summary: Soft delete automation rule
+  description: >
+    Soft deletes one automation rule for one automation agent owned by the authenticated user.
+    This operation is idempotent.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: agentId
+      required: true
+      schema:
+        type: string
+        format: uuid
+    - in: path
+      name: ruleId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    '200':
+      description: Rule delete status
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/DeleteAgentRuleResponseDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/atmssox/rest/paths/v1/agents-rules.yml
+++ b/apis/atmssox/rest/paths/v1/agents-rules.yml
@@ -1,0 +1,73 @@
+get:
+  tags:
+    - Agent
+  operationId: getAgentRules
+  summary: Get active automation rules
+  description: >
+    Returns active rules for one automation agent owned by the authenticated user.
+    Rules are sorted by createdAt ascending.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: agentId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    '200':
+      description: Active rules collection
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/AgentRulesResponseDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'
+post:
+  tags:
+    - Agent
+  operationId: createAgentRule
+  summary: Create automation rule
+  description: >
+    Creates one active rule for one automation agent owned by the authenticated user.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: agentId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/CreateAgentRuleRequestDTO'
+  responses:
+    '201':
+      description: Created rule
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/AgentRuleDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/atmssox/rest/schemas/v1/agent/agent-rule-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/agent-rule-dto.yml
@@ -1,0 +1,25 @@
+AgentRuleDTO:
+  title: AgentRuleDTO
+  type: object
+  additionalProperties: false
+  required:
+    - id
+    - text
+    - createdAt
+    - updatedAt
+  properties:
+    id:
+      type: string
+      format: uuid
+      description: Globally unique rule identifier.
+    text:
+      type: string
+      description: Rule text used in agent execution context.
+    createdAt:
+      type: string
+      format: date-time
+      description: Rule creation timestamp (UTC).
+    updatedAt:
+      type: string
+      format: date-time
+      description: Last rule update timestamp (UTC).

--- a/apis/atmssox/rest/schemas/v1/agent/agent-rules-response-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/agent-rules-response-dto.yml
@@ -1,0 +1,12 @@
+AgentRulesResponseDTO:
+  title: AgentRulesResponseDTO
+  type: object
+  additionalProperties: false
+  required:
+    - items
+  properties:
+    items:
+      type: array
+      description: Active automation rules for one agent.
+      items:
+        $ref: '../../../openapi.yml#/components/schemas/AgentRuleDTO'

--- a/apis/atmssox/rest/schemas/v1/agent/create-agent-rule-request-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/create-agent-rule-request-dto.yml
@@ -1,0 +1,13 @@
+CreateAgentRuleRequestDTO:
+  title: CreateAgentRuleRequestDTO
+  type: object
+  additionalProperties: false
+  required:
+    - text
+  properties:
+    text:
+      type: string
+      minLength: 1
+      pattern: ".*\\S.*"
+      description: Rule text. Value is trimmed before validation.
+      example: Always write clean and maintainable code.

--- a/apis/atmssox/rest/schemas/v1/agent/delete-agent-rule-response-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/delete-agent-rule-response-dto.yml
@@ -1,0 +1,13 @@
+DeleteAgentRuleResponseDTO:
+  title: DeleteAgentRuleResponseDTO
+  type: object
+  additionalProperties: false
+  required:
+    - status
+  properties:
+    status:
+      type: string
+      description: Rule status after delete action.
+      enum:
+        - DELETED
+      example: DELETED

--- a/apis/atmssox/rest/schemas/v1/agent/patch-agent-rule-request-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/patch-agent-rule-request-dto.yml
@@ -1,0 +1,13 @@
+PatchAgentRuleRequestDTO:
+  title: PatchAgentRuleRequestDTO
+  type: object
+  additionalProperties: false
+  required:
+    - text
+  properties:
+    text:
+      type: string
+      minLength: 1
+      pattern: ".*\\S.*"
+      description: Updated rule text. Value is trimmed before validation.
+      example: Always write clean, maintainable, and explicit code.

--- a/apis/bffssox/rest/metadata.yml
+++ b/apis/bffssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.27
+  version: 0.0.28
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/bffssox/rest/openapi.yml
+++ b/apis/bffssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Backend for Frontend Sitionix
   description: API specification for the BFF authentication facade
-  version: 0.0.27
+  version: 0.0.28
   contact:
     name: APP Sitionix
 servers:
@@ -38,6 +38,10 @@ paths:
     $ref: './paths/v1/agents-restore.yml'
   /api/v1/agents/{agentId}/chat:
     $ref: './paths/v1/agents-chat.yml'
+  /api/v1/agents/{agentId}/rules:
+    $ref: './paths/v1/agents-rules.yml'
+  /api/v1/agents/{agentId}/rules/{ruleId}:
+    $ref: './paths/v1/agents-rules-by-id.yml'
   /api/v1/agents/{agentId}/conversations:
     $ref: './paths/v1/agents-conversations.yml'
   /api/v1/conversations/{conversationId}:
@@ -92,6 +96,16 @@ components:
       $ref: './schemas/v1/agent/agent-conversations-response-dto.yml#/AgentConversationsResponseDTO'
     AgentConversationDetailsDTO:
       $ref: './schemas/v1/agent/agent-conversation-details-dto.yml#/AgentConversationDetailsDTO'
+    AgentRuleDTO:
+      $ref: './schemas/v1/agent/agent-rule-dto.yml#/AgentRuleDTO'
+    AgentRulesResponseDTO:
+      $ref: './schemas/v1/agent/agent-rules-response-dto.yml#/AgentRulesResponseDTO'
+    CreateAgentRuleRequestDTO:
+      $ref: './schemas/v1/agent/create-agent-rule-request-dto.yml#/CreateAgentRuleRequestDTO'
+    PatchAgentRuleRequestDTO:
+      $ref: './schemas/v1/agent/patch-agent-rule-request-dto.yml#/PatchAgentRuleRequestDTO'
+    DeleteAgentRuleResponseDTO:
+      $ref: './schemas/v1/agent/delete-agent-rule-response-dto.yml#/DeleteAgentRuleResponseDTO'
     WorkspaceSitesResponseDTO:
       $ref: './schemas/v1/site/workspace-sites-response-dto.yml#/WorkspaceSitesResponseDTO'
     SiteOverviewDTO:

--- a/apis/bffssox/rest/paths/v1/agents-rules-by-id.yml
+++ b/apis/bffssox/rest/paths/v1/agents-rules-by-id.yml
@@ -1,0 +1,88 @@
+patch:
+  tags:
+    - Agent
+  operationId: patchAgentRule
+  summary: Update active automation rule
+  description: >
+    Updates text of one active rule for one automation agent owned by the authenticated user.
+    Deleted rules are rejected in this flow.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: agentId
+      required: true
+      schema:
+        type: string
+        format: uuid
+    - in: path
+      name: ruleId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/PatchAgentRuleRequestDTO'
+  responses:
+    '200':
+      description: Updated rule
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/AgentRuleDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '409':
+      $ref: '../../openapi.yml#/components/responses/Conflict'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'
+delete:
+  tags:
+    - Agent
+  operationId: deleteAgentRule
+  summary: Soft delete automation rule
+  description: >
+    Soft deletes one automation rule for one automation agent owned by the authenticated user.
+    This operation is idempotent.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: agentId
+      required: true
+      schema:
+        type: string
+        format: uuid
+    - in: path
+      name: ruleId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    '200':
+      description: Rule delete status
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/DeleteAgentRuleResponseDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/bffssox/rest/paths/v1/agents-rules.yml
+++ b/apis/bffssox/rest/paths/v1/agents-rules.yml
@@ -1,0 +1,73 @@
+get:
+  tags:
+    - Agent
+  operationId: getAgentRules
+  summary: Get active automation rules
+  description: >
+    Returns active rules for one automation agent owned by the authenticated user.
+    Rules are sorted by createdAt ascending.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: agentId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    '200':
+      description: Active rules collection
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/AgentRulesResponseDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'
+post:
+  tags:
+    - Agent
+  operationId: createAgentRule
+  summary: Create automation rule
+  description: >
+    Creates one active rule for one automation agent owned by the authenticated user.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: agentId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/CreateAgentRuleRequestDTO'
+  responses:
+    '201':
+      description: Created rule
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/AgentRuleDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/bffssox/rest/schemas/v1/agent/agent-rule-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agent-rule-dto.yml
@@ -1,0 +1,25 @@
+AgentRuleDTO:
+  title: AgentRuleDTO
+  type: object
+  additionalProperties: false
+  required:
+    - id
+    - text
+    - createdAt
+    - updatedAt
+  properties:
+    id:
+      type: string
+      format: uuid
+      description: Globally unique rule identifier.
+    text:
+      type: string
+      description: Rule text used in agent execution context.
+    createdAt:
+      type: string
+      format: date-time
+      description: Rule creation timestamp (UTC).
+    updatedAt:
+      type: string
+      format: date-time
+      description: Last rule update timestamp (UTC).

--- a/apis/bffssox/rest/schemas/v1/agent/agent-rules-response-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agent-rules-response-dto.yml
@@ -1,0 +1,12 @@
+AgentRulesResponseDTO:
+  title: AgentRulesResponseDTO
+  type: object
+  additionalProperties: false
+  required:
+    - items
+  properties:
+    items:
+      type: array
+      description: Active automation rules for one agent.
+      items:
+        $ref: '../../../openapi.yml#/components/schemas/AgentRuleDTO'

--- a/apis/bffssox/rest/schemas/v1/agent/create-agent-rule-request-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/create-agent-rule-request-dto.yml
@@ -1,0 +1,13 @@
+CreateAgentRuleRequestDTO:
+  title: CreateAgentRuleRequestDTO
+  type: object
+  additionalProperties: false
+  required:
+    - text
+  properties:
+    text:
+      type: string
+      minLength: 1
+      pattern: ".*\\S.*"
+      description: Rule text. Value is trimmed before validation.
+      example: Always write clean and maintainable code.

--- a/apis/bffssox/rest/schemas/v1/agent/delete-agent-rule-response-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/delete-agent-rule-response-dto.yml
@@ -1,0 +1,13 @@
+DeleteAgentRuleResponseDTO:
+  title: DeleteAgentRuleResponseDTO
+  type: object
+  additionalProperties: false
+  required:
+    - status
+  properties:
+    status:
+      type: string
+      description: Rule status after delete action.
+      enum:
+        - DELETED
+      example: DELETED

--- a/apis/bffssox/rest/schemas/v1/agent/patch-agent-rule-request-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/patch-agent-rule-request-dto.yml
@@ -1,0 +1,13 @@
+PatchAgentRuleRequestDTO:
+  title: PatchAgentRuleRequestDTO
+  type: object
+  additionalProperties: false
+  required:
+    - text
+  properties:
+    text:
+      type: string
+      minLength: 1
+      pattern: ".*\\S.*"
+      description: Updated rule text. Value is trimmed before validation.
+      example: Always write clean, maintainable, and explicit code.


### PR DESCRIPTION
## Summary
- add rules endpoints for atmssox and bffssox rest surfaces
- add request/response schemas for rules CRUD and delete status
- bump rest contract versions for both surfaces
