### PR TITLE
[SITIONIX-119] - fix agent rule dto naming collision

### DIFF
--- a/apis/atmssox/rest/metadata.yml
+++ b/apis/atmssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.12
+  version: 0.0.13
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/atmssox/rest/openapi.yml
+++ b/apis/atmssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Automation Service Sitionix
   description: API specification for automation service
-  version: 0.0.12
+  version: 0.0.13
   contact:
     name: APP Sitionix
 servers:

--- a/apis/atmssox/rest/schemas/v1/agent/agent-conversation-details-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/agent-conversation-details-dto.yml
@@ -39,4 +39,4 @@ AgentConversationDetailsDTO:
       type: array
       description: Full ordered message history.
       items:
-        $ref: '../../../openapi.yml#/components/schemas/AgentConversationMessageDTO'
+        $ref: './agent-conversation-message-dto.yml#/AgentConversationMessageDTO'

--- a/apis/atmssox/rest/schemas/v1/agent/agent-conversations-response-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/agent-conversations-response-dto.yml
@@ -9,4 +9,4 @@ AgentConversationsResponseDTO:
       type: array
       description: Conversations for one agent and current user.
       items:
-        $ref: '../../../openapi.yml#/components/schemas/AgentConversationDTO'
+        $ref: './agent-conversation-dto.yml#/AgentConversationDTO'

--- a/apis/atmssox/rest/schemas/v1/agent/agent-rule-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/agent-rule-dto.yml
@@ -27,9 +27,9 @@ AgentRuleDTO:
       type: string
       description: Rule content used in execution context.
     status:
-      $ref: '../../../openapi.yml#/components/schemas/AgentRuleStatusDTO'
+      $ref: './agent-rule-status-dto.yml#/AgentRuleStatusDTO'
     authorType:
-      $ref: '../../../openapi.yml#/components/schemas/AgentRuleAuthorTypeDTO'
+      $ref: './agent-rule-author-type-dto.yml#/AgentRuleAuthorTypeDTO'
     createdAt:
       type: string
       format: date-time

--- a/apis/atmssox/rest/schemas/v1/agent/agent-rules-response-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/agent-rules-response-dto.yml
@@ -9,4 +9,4 @@ AgentRulesResponseDTO:
       type: array
       description: Automation rules for one agent.
       items:
-        $ref: '../../../openapi.yml#/components/schemas/AgentRuleDTO'
+        $ref: './agent-rule-dto.yml#/AgentRuleDTO'

--- a/apis/atmssox/rest/schemas/v1/agent/agents-response-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/agents-response-dto.yml
@@ -9,4 +9,4 @@ AgentsResponseDTO:
       type: array
       description: Persisted automation agents.
       items:
-        $ref: '../../../openapi.yml#/components/schemas/AgentDTO'
+        $ref: './agent-dto.yml#/AgentDTO'

--- a/apis/atmssox/rest/schemas/v1/agent/chat-agent-response-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/chat-agent-response-dto.yml
@@ -11,4 +11,4 @@ ChatAgentResponseDTO:
       format: uuid
       description: Conversation identifier where message was persisted.
     reply:
-      $ref: '../../../openapi.yml#/components/schemas/AgentConversationMessageDTO'
+      $ref: './agent-conversation-message-dto.yml#/AgentConversationMessageDTO'

--- a/apis/bffssox/rest/metadata.yml
+++ b/apis/bffssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.29
+  version: 0.0.30
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/bffssox/rest/openapi.yml
+++ b/apis/bffssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Backend for Frontend Sitionix
   description: API specification for the BFF authentication facade
-  version: 0.0.29
+  version: 0.0.30
   contact:
     name: APP Sitionix
 servers:

--- a/apis/bffssox/rest/schemas/v1/agent/agent-conversation-details-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agent-conversation-details-dto.yml
@@ -39,4 +39,4 @@ AgentConversationDetailsDTO:
       type: array
       description: Full ordered message history.
       items:
-        $ref: '../../../openapi.yml#/components/schemas/AgentConversationMessageDTO'
+        $ref: './agent-conversation-message-dto.yml#/AgentConversationMessageDTO'

--- a/apis/bffssox/rest/schemas/v1/agent/agent-conversations-response-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agent-conversations-response-dto.yml
@@ -9,4 +9,4 @@ AgentConversationsResponseDTO:
       type: array
       description: Conversations for one agent and current user.
       items:
-        $ref: '../../../openapi.yml#/components/schemas/AgentConversationDTO'
+        $ref: './agent-conversation-dto.yml#/AgentConversationDTO'

--- a/apis/bffssox/rest/schemas/v1/agent/agent-rule-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agent-rule-dto.yml
@@ -27,9 +27,9 @@ AgentRuleDTO:
       type: string
       description: Rule content used in execution context.
     status:
-      $ref: '../../../openapi.yml#/components/schemas/AgentRuleStatusDTO'
+      $ref: './agent-rule-status-dto.yml#/AgentRuleStatusDTO'
     authorType:
-      $ref: '../../../openapi.yml#/components/schemas/AgentRuleAuthorTypeDTO'
+      $ref: './agent-rule-author-type-dto.yml#/AgentRuleAuthorTypeDTO'
     createdAt:
       type: string
       format: date-time

--- a/apis/bffssox/rest/schemas/v1/agent/agent-rules-response-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agent-rules-response-dto.yml
@@ -9,4 +9,4 @@ AgentRulesResponseDTO:
       type: array
       description: Automation rules for one agent.
       items:
-        $ref: '../../../openapi.yml#/components/schemas/AgentRuleDTO'
+        $ref: './agent-rule-dto.yml#/AgentRuleDTO'

--- a/apis/bffssox/rest/schemas/v1/agent/agents-response-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agents-response-dto.yml
@@ -9,4 +9,4 @@ AgentsResponseDTO:
       type: array
       description: Persisted automation agents.
       items:
-        $ref: '../../../openapi.yml#/components/schemas/AgentDTO'
+        $ref: './agent-dto.yml#/AgentDTO'

--- a/apis/bffssox/rest/schemas/v1/agent/chat-agent-response-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/chat-agent-response-dto.yml
@@ -11,4 +11,4 @@ ChatAgentResponseDTO:
       format: uuid
       description: Conversation identifier where message was persisted.
     reply:
-      $ref: '../../../openapi.yml#/components/schemas/AgentConversationMessageDTO'
+      $ref: './agent-conversation-message-dto.yml#/AgentConversationMessageDTO'


### PR DESCRIPTION
## Summary
- fix rules response schema refs to prevent generated AgentRuleDTO1 naming collision
- bump atmssox rest version to 0.0.13
- bump bffssox rest version to 0.0.30

## Scope
- app-afesox only (api-first source)
