### PR TITLE
[SITIONIX-126-10] - fix nullable ref composition for agent conversation dto

### DIFF
--- a/apis/atmssox/rest/metadata.yml
+++ b/apis/atmssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.14
+  version: 0.0.15
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/atmssox/rest/metadata.yml
+++ b/apis/atmssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.16
+  version: 0.0.17
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/atmssox/rest/metadata.yml
+++ b/apis/atmssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.15
+  version: 0.0.16
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/atmssox/rest/openapi.yml
+++ b/apis/atmssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Automation Service Sitionix
   description: API specification for automation service
-  version: 0.0.14
+  version: 0.0.15
   contact:
     name: APP Sitionix
 servers:

--- a/apis/atmssox/rest/openapi.yml
+++ b/apis/atmssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Automation Service Sitionix
   description: API specification for automation service
-  version: 0.0.15
+  version: 0.0.16
   contact:
     name: APP Sitionix
 servers:

--- a/apis/atmssox/rest/openapi.yml
+++ b/apis/atmssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Automation Service Sitionix
   description: API specification for automation service
-  version: 0.0.16
+  version: 0.0.17
   contact:
     name: APP Sitionix
 servers:

--- a/apis/atmssox/rest/schemas/v1/agent/agent-conversation-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/agent-conversation-dto.yml
@@ -35,5 +35,5 @@ AgentConversationDTO:
       format: date-time
       description: Last message timestamp for list sorting (UTC).
     latestExecution:
-      $ref: './chat-execution-dto.yml#/ChatExecutionDTO'
+      $ref: '../../../openapi.yml#/components/schemas/ChatExecutionDTO'
       nullable: true

--- a/apis/atmssox/rest/schemas/v1/agent/agent-conversation-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/agent-conversation-dto.yml
@@ -35,6 +35,5 @@ AgentConversationDTO:
       format: date-time
       description: Last message timestamp for list sorting (UTC).
     latestExecution:
+      $ref: './chat-execution-dto.yml#/ChatExecutionDTO'
       nullable: true
-      allOf:
-        - $ref: './chat-execution-dto.yml#/ChatExecutionDTO'

--- a/apis/atmssox/rest/schemas/v1/agent/agent-conversations-response-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/agent-conversations-response-dto.yml
@@ -9,4 +9,4 @@ AgentConversationsResponseDTO:
       type: array
       description: Conversations for one agent and current user.
       items:
-        $ref: './agent-conversation-dto.yml#/AgentConversationDTO'
+        $ref: '../../../openapi.yml#/components/schemas/AgentConversationDTO'

--- a/apis/atmssox/rest/schemas/v1/agent/chat-agent-response-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/chat-agent-response-dto.yml
@@ -1,4 +1,2 @@
 ChatAgentResponseDTO:
-  title: ChatAgentResponseDTO
-  allOf:
-    - $ref: './chat-agent-execution-dto.yml#/ChatAgentExecutionDTO'
+  $ref: './chat-agent-execution-dto.yml#/ChatAgentExecutionDTO'

--- a/apis/atmssox/rest/schemas/v1/agent/chat-execution-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/chat-execution-dto.yml
@@ -33,10 +33,8 @@ ChatExecutionDTO:
       nullable: true
       description: Terminal execution timestamp (UTC).
     error:
+      $ref: '../../../openapi.yml#/components/schemas/ChatExecutionFailureDTO'
       nullable: true
-      allOf:
-        - $ref: './chat-execution-failure-dto.yml#/ChatExecutionFailureDTO'
     assistantMessage:
+      $ref: '../../../openapi.yml#/components/schemas/AgentConversationMessageDTO'
       nullable: true
-      allOf:
-        - $ref: './agent-conversation-message-dto.yml#/AgentConversationMessageDTO'

--- a/apis/atmssox/rest/schemas/v1/agent/submit-chat-execution-response-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/submit-chat-execution-response-dto.yml
@@ -23,9 +23,8 @@ SubmitChatExecutionResponseDTO:
       format: date-time
       description: Execution acceptance timestamp (UTC).
     error:
+      $ref: '../../../openapi.yml#/components/schemas/ChatExecutionFailureDTO'
       nullable: true
-      allOf:
-        - $ref: './chat-execution-failure-dto.yml#/ChatExecutionFailureDTO'
     idempotencyKey:
       type: string
       description: Echoed idempotency key when provided.

--- a/apis/bffssox/rest/schemas/v1/agent/agent-conversation-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agent-conversation-dto.yml
@@ -35,5 +35,6 @@ AgentConversationDTO:
       format: date-time
       description: Last message timestamp for list sorting (UTC).
     latestExecution:
-      $ref: './chat-execution-dto.yml#/ChatExecutionDTO'
       nullable: true
+      allOf:
+        - $ref: './chat-execution-dto.yml#/ChatExecutionDTO'

--- a/apis/bffssox/rest/schemas/v1/agent/agent-conversation-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agent-conversation-dto.yml
@@ -35,6 +35,5 @@ AgentConversationDTO:
       format: date-time
       description: Last message timestamp for list sorting (UTC).
     latestExecution:
+      $ref: './chat-execution-dto.yml#/ChatExecutionDTO'
       nullable: true
-      allOf:
-        - $ref: './chat-execution-dto.yml#/ChatExecutionDTO'


### PR DESCRIPTION
Fix OpenAPI nullable reference composition to prevent generated *DTO1 aliases in stable artifacts.

- atmssox AgentConversationDTO.latestExecution
- bffssox AgentConversationDTO.latestExecution

No functional API behavior change.