### PR TITLE
[SITIONIX-127] - rename userMessageId to inputMessageId in chat contracts

### DIFF
--- a/apis/atmssox/rest/metadata.yml
+++ b/apis/atmssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.18
+  version: 0.0.19
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/atmssox/rest/metadata.yml
+++ b/apis/atmssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.17
+  version: 0.0.18
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/atmssox/rest/metadata.yml
+++ b/apis/atmssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.19
+  version: 0.0.18
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/atmssox/rest/openapi.yml
+++ b/apis/atmssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Automation Service Sitionix
   description: API specification for automation service
-  version: 0.0.17
+  version: 0.0.18
   contact:
     name: APP Sitionix
 servers:

--- a/apis/atmssox/rest/openapi.yml
+++ b/apis/atmssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Automation Service Sitionix
   description: API specification for automation service
-  version: 0.0.18
+  version: 0.0.19
   contact:
     name: APP Sitionix
 servers:

--- a/apis/atmssox/rest/openapi.yml
+++ b/apis/atmssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Automation Service Sitionix
   description: API specification for automation service
-  version: 0.0.19
+  version: 0.0.18
   contact:
     name: APP Sitionix
 servers:

--- a/apis/atmssox/rest/schemas/v1/agent/chat-agent-execution-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/chat-agent-execution-dto.yml
@@ -30,7 +30,7 @@ ChatAgentExecutionDTO:
       type: string
       format: uuid
       description: Conversation identifier linked to the execution.
-    userMessageId:
+    inputMessageId:
       type: string
       format: uuid
       description: Persisted user message identifier.

--- a/apis/atmssox/rest/schemas/v1/agent/submit-chat-execution-response-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/submit-chat-execution-response-dto.yml
@@ -5,6 +5,7 @@ SubmitChatExecutionResponseDTO:
   required:
     - executionId
     - conversationId
+    - userMessageId
     - status
     - acceptedAt
   properties:
@@ -16,6 +17,10 @@ SubmitChatExecutionResponseDTO:
       type: string
       format: uuid
       description: Conversation identifier linked to this execution.
+    userMessageId:
+      type: string
+      format: uuid
+      description: User message identifier persisted during submit transaction.
     status:
       $ref: './execution-status-dto.yml#/ExecutionStatusDTO'
     acceptedAt:

--- a/apis/atmssox/rest/schemas/v1/agent/submit-chat-execution-response-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/submit-chat-execution-response-dto.yml
@@ -5,7 +5,7 @@ SubmitChatExecutionResponseDTO:
   required:
     - executionId
     - conversationId
-    - userMessageId
+    - inputMessageId
     - status
     - acceptedAt
   properties:
@@ -17,7 +17,7 @@ SubmitChatExecutionResponseDTO:
       type: string
       format: uuid
       description: Conversation identifier linked to this execution.
-    userMessageId:
+    inputMessageId:
       type: string
       format: uuid
       description: User message identifier persisted during submit transaction.

--- a/apis/bffssox/rest/metadata.yml
+++ b/apis/bffssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.33
+  version: 0.0.32
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/bffssox/rest/metadata.yml
+++ b/apis/bffssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.32
+  version: 0.0.33
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/bffssox/rest/metadata.yml
+++ b/apis/bffssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.31
+  version: 0.0.32
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/bffssox/rest/openapi.yml
+++ b/apis/bffssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Backend for Frontend Sitionix
   description: API specification for the BFF authentication facade
-  version: 0.0.31
+  version: 0.0.32
   contact:
     name: APP Sitionix
 servers:

--- a/apis/bffssox/rest/openapi.yml
+++ b/apis/bffssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Backend for Frontend Sitionix
   description: API specification for the BFF authentication facade
-  version: 0.0.32
+  version: 0.0.33
   contact:
     name: APP Sitionix
 servers:

--- a/apis/bffssox/rest/openapi.yml
+++ b/apis/bffssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Backend for Frontend Sitionix
   description: API specification for the BFF authentication facade
-  version: 0.0.33
+  version: 0.0.32
   contact:
     name: APP Sitionix
 servers:

--- a/apis/bffssox/rest/schemas/v1/agent/chat-agent-execution-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/chat-agent-execution-dto.yml
@@ -30,7 +30,7 @@ ChatAgentExecutionDTO:
       type: string
       format: uuid
       description: Conversation identifier linked to the execution.
-    userMessageId:
+    inputMessageId:
       type: string
       format: uuid
       description: Persisted user message identifier.

--- a/apis/bffssox/rest/schemas/v1/agent/submit-chat-execution-response-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/submit-chat-execution-response-dto.yml
@@ -5,6 +5,7 @@ SubmitChatExecutionResponseDTO:
   required:
     - executionId
     - conversationId
+    - userMessageId
     - status
     - acceptedAt
   properties:
@@ -16,6 +17,10 @@ SubmitChatExecutionResponseDTO:
       type: string
       format: uuid
       description: Conversation identifier linked to this execution.
+    userMessageId:
+      type: string
+      format: uuid
+      description: User message identifier persisted during submit transaction.
     status:
       $ref: './execution-status-dto.yml#/ExecutionStatusDTO'
     acceptedAt:

--- a/apis/bffssox/rest/schemas/v1/agent/submit-chat-execution-response-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/submit-chat-execution-response-dto.yml
@@ -5,7 +5,7 @@ SubmitChatExecutionResponseDTO:
   required:
     - executionId
     - conversationId
-    - userMessageId
+    - inputMessageId
     - status
     - acceptedAt
   properties:
@@ -17,7 +17,7 @@ SubmitChatExecutionResponseDTO:
       type: string
       format: uuid
       description: Conversation identifier linked to this execution.
-    userMessageId:
+    inputMessageId:
       type: string
       format: uuid
       description: User message identifier persisted during submit transaction.


### PR DESCRIPTION
## Summary
- add required userMessageId to ATMS submit async execution response schema
- add required userMessageId to BFF submit async execution response schema

## Why
- align async lifecycle contract with immediate USER message persistence and execution linkage