### PR TITLE
[SITIONIX-128] - add soft-delete conversation api contract

### DIFF
--- a/apis/atmssox/rest/metadata.yml
+++ b/apis/atmssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.18
+  version: 0.0.19
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/atmssox/rest/openapi.yml
+++ b/apis/atmssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Automation Service Sitionix
   description: API specification for automation service
-  version: 0.0.18
+  version: 0.0.19
   contact:
     name: APP Sitionix
 servers:

--- a/apis/atmssox/rest/paths/v1/agents-conversations-by-id.yml
+++ b/apis/atmssox/rest/paths/v1/agents-conversations-by-id.yml
@@ -30,3 +30,32 @@ get:
       $ref: '../../openapi.yml#/components/responses/NotFound'
     '500':
       $ref: '../../openapi.yml#/components/responses/InternalServerError'
+delete:
+  tags:
+    - Agent
+  operationId: deleteAgentConversation
+  summary: Soft delete agent conversation
+  description: >
+    Soft deletes one conversation owned by the authenticated user.
+    This operation is idempotent: repeated calls on an already `DELETED`
+    conversation return `204` with no response body.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: conversationId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    '204':
+      description: Conversation soft deleted
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/bffssox/rest/metadata.yml
+++ b/apis/bffssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.32
+  version: 0.0.33
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/bffssox/rest/openapi.yml
+++ b/apis/bffssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Backend for Frontend Sitionix
   description: API specification for the BFF authentication facade
-  version: 0.0.32
+  version: 0.0.33
   contact:
     name: APP Sitionix
 servers:

--- a/apis/bffssox/rest/paths/v1/agents-conversations-by-id.yml
+++ b/apis/bffssox/rest/paths/v1/agents-conversations-by-id.yml
@@ -30,3 +30,32 @@ get:
       $ref: '../../openapi.yml#/components/responses/NotFound'
     '500':
       $ref: '../../openapi.yml#/components/responses/InternalServerError'
+delete:
+  tags:
+    - Agent
+  operationId: deleteAgentConversation
+  summary: Soft delete agent conversation
+  description: >
+    Soft deletes one conversation owned by the authenticated user.
+    This operation is idempotent: repeated calls on an already `DELETED`
+    conversation return `204` with no response body.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: conversationId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    '204':
+      description: Conversation soft deleted
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'


### PR DESCRIPTION
## Summary\n- add DELETE /api/v1/conversations/{conversationId} to atmssox and bffssox contracts\n- keep idempotent 204 behavior\n- bump atmssox rest version 0.0.18 -> 0.0.19\n- bump bffssox rest version 0.0.32 -> 0.0.33\n\n## Why\nEnable end-to-end soft-delete conversation flow for automation/bff/spa.