### PR TITLE
[SITIONIX-132] - add agent project patch and delete contracts

### DIFF
--- a/apis/atmssox/rest/metadata.yml
+++ b/apis/atmssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.22
+  version: 0.0.23
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/atmssox/rest/openapi.yml
+++ b/apis/atmssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Automation Service Sitionix
   description: API specification for automation service
-  version: 0.0.22
+  version: 0.0.23
   contact:
     name: APP Sitionix
 servers:
@@ -61,6 +61,8 @@ components:
       $ref: './schemas/v1/agent/create-agent-project-request-dto.yml#/CreateAgentProjectRequestDTO'
     PatchAgentRequestDTO:
       $ref: './schemas/v1/agent/patch-agent-request-dto.yml#/PatchAgentRequestDTO'
+    PatchAgentProjectRequestDTO:
+      $ref: './schemas/v1/agent/patch-agent-project-request-dto.yml#/PatchAgentProjectRequestDTO'
     AgentDTO:
       $ref: './schemas/v1/agent/agent-dto.yml#/AgentDTO'
     AgentProjectDTO:

--- a/apis/atmssox/rest/paths/v1/agent-projects-by-id.yml
+++ b/apis/atmssox/rest/paths/v1/agent-projects-by-id.yml
@@ -30,3 +30,67 @@ get:
       $ref: '../../openapi.yml#/components/responses/NotFound'
     '500':
       $ref: '../../openapi.yml#/components/responses/InternalServerError'
+patch:
+  tags:
+    - AgentProject
+  operationId: patchAgentProject
+  summary: Patch agent project identity
+  description: >
+    Partially updates one automation project for the authenticated user.
+    Supports only `name` and `description` fields.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: projectId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/PatchAgentProjectRequestDTO'
+  responses:
+    '200':
+      description: Updated agent project details
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/AgentProjectDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'
+delete:
+  tags:
+    - AgentProject
+  operationId: deleteAgentProject
+  summary: Soft delete agent project
+  description: >
+    Soft deletes one automation project for the authenticated user.
+    Once deleted, it is hidden from list and details responses.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: projectId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    '204':
+      description: Project deleted
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/atmssox/rest/schemas/v1/agent/patch-agent-project-request-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/patch-agent-project-request-dto.yml
@@ -1,0 +1,22 @@
+PatchAgentProjectRequestDTO:
+  title: PatchAgentProjectRequestDTO
+  type: object
+  additionalProperties: false
+  anyOf:
+    - required:
+        - name
+    - required:
+        - description
+  properties:
+    name:
+      type: string
+      minLength: 1
+      maxLength: 120
+      pattern: ".*\\S.*"
+      description: Human-readable agent project name. Value is trimmed before validation.
+      example: Updated Marketing Automation
+    description:
+      type: string
+      maxLength: 1000
+      description: Optional project description. Empty or blank value can be normalized during patch processing.
+      example: Updated project description

--- a/apis/bffssox/rest/metadata.yml
+++ b/apis/bffssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.36
+  version: 0.0.37
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/bffssox/rest/openapi.yml
+++ b/apis/bffssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Backend for Frontend Sitionix
   description: API specification for the BFF authentication facade
-  version: 0.0.36
+  version: 0.0.37
   contact:
     name: APP Sitionix
 servers:
@@ -98,6 +98,8 @@ components:
       $ref: './schemas/v1/agent/create-agent-project-request-dto.yml#/CreateAgentProjectRequestDTO'
     PatchAgentRequestDTO:
       $ref: './schemas/v1/agent/patch-agent-request-dto.yml#/PatchAgentRequestDTO'
+    PatchAgentProjectRequestDTO:
+      $ref: './schemas/v1/agent/patch-agent-project-request-dto.yml#/PatchAgentProjectRequestDTO'
     AgentDTO:
       $ref: './schemas/v1/agent/agent-dto.yml#/AgentDTO'
     AgentProjectDTO:

--- a/apis/bffssox/rest/paths/v1/agent-projects-by-id.yml
+++ b/apis/bffssox/rest/paths/v1/agent-projects-by-id.yml
@@ -30,3 +30,67 @@ get:
       $ref: '../../openapi.yml#/components/responses/NotFound'
     '500':
       $ref: '../../openapi.yml#/components/responses/InternalServerError'
+patch:
+  tags:
+    - AgentProject
+  operationId: patchAgentProject
+  summary: Patch automation project identity
+  description: >
+    Partially updates one automation project for the authenticated user.
+    Supports only `name` and `description` fields.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: projectId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/PatchAgentProjectRequestDTO'
+  responses:
+    '200':
+      description: Updated agent project details
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/AgentProjectDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'
+delete:
+  tags:
+    - AgentProject
+  operationId: deleteAgentProject
+  summary: Soft delete automation project
+  description: >
+    Soft deletes one automation project for the authenticated user.
+    Once deleted, it is hidden from list and details responses.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: projectId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    '204':
+      description: Project deleted
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/bffssox/rest/schemas/v1/agent/patch-agent-project-request-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/patch-agent-project-request-dto.yml
@@ -1,0 +1,22 @@
+PatchAgentProjectRequestDTO:
+  title: PatchAgentProjectRequestDTO
+  type: object
+  additionalProperties: false
+  anyOf:
+    - required:
+        - name
+    - required:
+        - description
+  properties:
+    name:
+      type: string
+      minLength: 1
+      maxLength: 120
+      pattern: ".*\\S.*"
+      description: Human-readable agent project name. Value is trimmed before validation.
+      example: Updated Marketing Automation
+    description:
+      type: string
+      maxLength: 1000
+      description: Optional project description. Empty or blank value can be normalized during patch processing.
+      example: Updated project description


### PR DESCRIPTION
## Summary
- add PATCH /api/v1/agent-projects/{projectId} for atmssox and bffssox contracts
- add DELETE /api/v1/agent-projects/{projectId} with 204 response
- add PatchAgentProjectRequestDTO schema and bump API versions

## Why
Enable generated artifacts required for SITIONIX-132 BE/FE implementation.
