### PR TITLE
[SITIONIX-3] - Add analyzer lane completion DTO contract

### DIFF
--- a/apis/fgaisox/rest/metadata.yml
+++ b/apis/fgaisox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.2
+  version: 0.0.3
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -35,6 +35,8 @@ components:
       $ref: './schemas/v1/forgeai/analyzer-qa-lead-handoff-dto.yml#/AnalyzerQaLeadHandoffDTO'
     CompleteAnalyzerLaneResponseDTO:
       $ref: './schemas/v1/forgeai/complete-analyzer-lane-response-dto.yml#/CompleteAnalyzerLaneResponseDTO'
+    AgentDTO:
+      $ref: './schemas/shared/agent-dto.yml#/AgentDTO'
     ErrorDTO:
       $ref: '../../common/rest/error/error-dto.yml#/ErrorDTO'
   responses:

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Forge AI Service Sitionix
   description: API specification for Forge AI service
-  version: 0.0.2
+  version: 0.0.3
   contact:
     name: APP Sitionix
 servers:
@@ -13,6 +13,8 @@ tags:
 paths:
   /api/v1/forge-ai/start:
     $ref: './paths/v1/forge-ai-start.yml'
+  /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/analyzer/complete:
+    $ref: './paths/v1/forge-ai-complete-analyzer-lane.yml'
 components:
   securitySchemes:
     bearerAuth:
@@ -25,11 +27,23 @@ components:
       $ref: './schemas/v1/forgeai/start-forge-request-dto.yml#/StartForgeRequestDTO'
     StartForgeResponseDTO:
       $ref: './schemas/v1/forgeai/start-forge-response-dto.yml#/StartForgeResponseDTO'
+    CompleteAnalyzerLaneRequestDTO:
+      $ref: './schemas/v1/forgeai/complete-analyzer-lane-request-dto.yml#/CompleteAnalyzerLaneRequestDTO'
+    AnalyzerArchitectHandoffDTO:
+      $ref: './schemas/v1/forgeai/analyzer-architect-handoff-dto.yml#/AnalyzerArchitectHandoffDTO'
+    AnalyzerQaLeadHandoffDTO:
+      $ref: './schemas/v1/forgeai/analyzer-qa-lead-handoff-dto.yml#/AnalyzerQaLeadHandoffDTO'
+    CompleteAnalyzerLaneResponseDTO:
+      $ref: './schemas/v1/forgeai/complete-analyzer-lane-response-dto.yml#/CompleteAnalyzerLaneResponseDTO'
     ErrorDTO:
       $ref: '../../common/rest/error/error-dto.yml#/ErrorDTO'
   responses:
     BadRequest:
       $ref: '../../common/rest/error/responses.yml#/BadRequest'
+    NotFound:
+      $ref: '../../common/rest/error/responses.yml#/NotFound'
+    Conflict:
+      $ref: '../../common/rest/error/responses.yml#/Conflict'
     Unauthorized:
       $ref: '../../common/rest/error/responses.yml#/Unauthorized'
     Forbidden:

--- a/apis/fgaisox/rest/paths/v1/forge-ai-complete-analyzer-lane.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-complete-analyzer-lane.yml
@@ -1,0 +1,45 @@
+post:
+  tags:
+    - ForgeAI
+  summary: Complete analyzer lane
+  operationId: completeAnalyzerLane
+  parameters:
+    - name: ticketId
+      in: path
+      required: true
+      description: Ticket identifier.
+      schema:
+        type: string
+        format: uuid
+    - name: laneId
+      in: path
+      required: true
+      description: Lane identifier.
+      schema:
+        type: string
+        format: uuid
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/CompleteAnalyzerLaneRequestDTO'
+  responses:
+    '200':
+      description: Analyzer lane completed successfully.
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/CompleteAnalyzerLaneResponseDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '409':
+      $ref: '../../openapi.yml#/components/responses/Conflict'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/fgaisox/rest/schemas/shared/agent-dto.yml
+++ b/apis/fgaisox/rest/schemas/shared/agent-dto.yml
@@ -2,13 +2,13 @@ AgentDTO:
   type: string
   description: Supported Forge AI agent identifier.
   enum:
-    - analyzer
-    - architect
-    - api
-    - event
-    - qa_lead
-    - implement_be
-    - implement_fe
-    - test_unit
-    - test_it
-    - test_ui
+    - ANALYZER
+    - ARCHITECT
+    - API
+    - EVENT
+    - QA_LEAD
+    - IMPLEMENT_BE
+    - IMPLEMENT_FE
+    - TEST_UNIT
+    - TEST_IT
+    - TEST_UI

--- a/apis/fgaisox/rest/schemas/shared/agent-dto.yml
+++ b/apis/fgaisox/rest/schemas/shared/agent-dto.yml
@@ -1,0 +1,14 @@
+AgentDTO:
+  type: string
+  description: Supported Forge AI agent identifier.
+  enum:
+    - analyzer
+    - architect
+    - api
+    - event
+    - qa_lead
+    - implement_be
+    - implement_fe
+    - test_unit
+    - test_it
+    - test_ui

--- a/apis/fgaisox/rest/schemas/v1/forgeai/analyzer-architect-handoff-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/analyzer-architect-handoff-dto.yml
@@ -1,0 +1,71 @@
+AnalyzerArchitectHandoffDTO:
+  type: object
+  description: Handoff payload produced by analyzer for architect lane.
+  required:
+    - task
+    - scope
+    - summary
+    - requirements
+    - constraints
+    - nonGoals
+    - risks
+    - dependencies
+    - expectedOutput
+  properties:
+    writtenBy:
+      type: string
+      description: Agent identity that produced this handoff.
+      example: analyzer(automationservice-sox)
+    sourceOutput:
+      type: string
+      nullable: true
+      description: Optional reference to analyzer output artifact.
+    task:
+      type: string
+      minLength: 1
+      description: Task statement for architect lane.
+    scope:
+      type: string
+      minLength: 1
+      description: Service scope identifier.
+      example: automationservice-sox
+    summary:
+      type: string
+      minLength: 1
+      description: Scope-specific architecture summary.
+    requirements:
+      type: array
+      description: Functional requirements for architect lane.
+      items:
+        type: string
+        description: Requirement item.
+    constraints:
+      type: array
+      description: Implementation constraints.
+      items:
+        type: string
+        description: Constraint item.
+    nonGoals:
+      type: array
+      description: Explicit non-goals for this lane.
+      items:
+        type: string
+        description: Non-goal item.
+    risks:
+      type: array
+      description: Known risks.
+      items:
+        type: string
+        description: Risk item.
+    dependencies:
+      type: array
+      description: External dependencies and prerequisites.
+      items:
+        type: string
+        description: Dependency item.
+    expectedOutput:
+      type: array
+      description: Expected artifacts from architect lane.
+      items:
+        type: string
+        description: Expected output item.

--- a/apis/fgaisox/rest/schemas/v1/forgeai/analyzer-architect-handoff-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/analyzer-architect-handoff-dto.yml
@@ -10,12 +10,10 @@ AnalyzerArchitectHandoffDTO:
     - nonGoals
     - risks
     - dependencies
-    - expectedOutput
   properties:
     writtenBy:
-      type: string
-      description: Agent identity that produced this handoff.
-      example: analyzer(automationservice-sox)
+      description: Agent that produced this handoff.
+      $ref: '../../shared/agent-dto.yml#/AgentDTO'
     sourceOutput:
       type: string
       nullable: true
@@ -63,9 +61,3 @@ AnalyzerArchitectHandoffDTO:
       items:
         type: string
         description: Dependency item.
-    expectedOutput:
-      type: array
-      description: Expected artifacts from architect lane.
-      items:
-        type: string
-        description: Expected output item.

--- a/apis/fgaisox/rest/schemas/v1/forgeai/analyzer-qa-lead-handoff-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/analyzer-qa-lead-handoff-dto.yml
@@ -1,0 +1,85 @@
+AnalyzerQaLeadHandoffDTO:
+  type: object
+  description: Handoff payload produced by analyzer for QA lead lane.
+  required:
+    - task
+    - scope
+    - summary
+    - scopeRequirements
+    - constraints
+    - nonGoals
+    - dependencies
+    - qualityFocus
+    - riskAreas
+    - edgeConsiderations
+    - expectedOutput
+  properties:
+    writtenBy:
+      type: string
+      description: Agent identity that produced this handoff.
+      example: analyzer(automationservice-sox)
+    sourceOutput:
+      type: string
+      nullable: true
+      description: Optional reference to analyzer output artifact.
+    task:
+      type: string
+      minLength: 1
+      description: Task statement for QA lead lane.
+    scope:
+      type: string
+      minLength: 1
+      description: Service scope identifier.
+      example: automationservice-sox
+    summary:
+      type: string
+      minLength: 1
+      description: Scope-specific testing summary.
+    scopeRequirements:
+      type: array
+      description: Scope requirements for QA strategy.
+      items:
+        type: string
+        description: Scope requirement item.
+    constraints:
+      type: array
+      description: Testing constraints.
+      items:
+        type: string
+        description: Constraint item.
+    nonGoals:
+      type: array
+      description: Explicit non-goals for QA lane.
+      items:
+        type: string
+        description: Non-goal item.
+    dependencies:
+      type: array
+      description: External dependencies and prerequisites.
+      items:
+        type: string
+        description: Dependency item.
+    qualityFocus:
+      type: array
+      description: Quality focus areas.
+      items:
+        type: string
+        description: Quality focus item.
+    riskAreas:
+      type: array
+      description: Risk areas to prioritize.
+      items:
+        type: string
+        description: Risk area item.
+    edgeConsiderations:
+      type: array
+      description: Edge cases to include.
+      items:
+        type: string
+        description: Edge consideration item.
+    expectedOutput:
+      type: array
+      description: Expected artifacts from QA lead lane.
+      items:
+        type: string
+        description: Expected output item.

--- a/apis/fgaisox/rest/schemas/v1/forgeai/analyzer-qa-lead-handoff-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/analyzer-qa-lead-handoff-dto.yml
@@ -12,12 +12,10 @@ AnalyzerQaLeadHandoffDTO:
     - qualityFocus
     - riskAreas
     - edgeConsiderations
-    - expectedOutput
   properties:
     writtenBy:
-      type: string
-      description: Agent identity that produced this handoff.
-      example: analyzer(automationservice-sox)
+      description: Agent that produced this handoff.
+      $ref: '../../shared/agent-dto.yml#/AgentDTO'
     sourceOutput:
       type: string
       nullable: true
@@ -77,9 +75,3 @@ AnalyzerQaLeadHandoffDTO:
       items:
         type: string
         description: Edge consideration item.
-    expectedOutput:
-      type: array
-      description: Expected artifacts from QA lead lane.
-      items:
-        type: string
-        description: Expected output item.

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-analyzer-lane-request-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-analyzer-lane-request-dto.yml
@@ -1,0 +1,16 @@
+CompleteAnalyzerLaneRequestDTO:
+  type: object
+  description: Analyzer completion payload with downstream handoff data.
+  required:
+    - summary
+    - architectHandoff
+    - qaLeadHandoff
+  properties:
+    summary:
+      type: string
+      minLength: 1
+      description: Short analyzer execution summary.
+    architectHandoff:
+      $ref: './analyzer-architect-handoff-dto.yml#/AnalyzerArchitectHandoffDTO'
+    qaLeadHandoff:
+      $ref: './analyzer-qa-lead-handoff-dto.yml#/AnalyzerQaLeadHandoffDTO'

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-analyzer-lane-response-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-analyzer-lane-response-dto.yml
@@ -1,0 +1,20 @@
+CompleteAnalyzerLaneResponseDTO:
+  type: object
+  description: Completion result for analyzer lane.
+  required:
+    - ticketId
+    - laneId
+    - laneStatus
+  properties:
+    ticketId:
+      type: string
+      format: uuid
+      description: Ticket identifier.
+    laneId:
+      type: string
+      format: uuid
+      description: Lane identifier.
+    laneStatus:
+      type: string
+      description: Updated lane status.
+      example: DONE


### PR DESCRIPTION
## Summary
- add Forge AI analyzer completion endpoint contract
- add request/response and handoff DTO schemas
- wire endpoint and schemas into fgaisox OpenAPI
- bump fgaisox rest metadata/api version to 0.0.3