### PR TITLE
[SITIONIX-31] - add architect lane completion API-first contract

### DIFF
--- a/apis/fgaisox/rest/metadata.yml
+++ b/apis/fgaisox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.3
+  version: 0.0.4
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Forge AI Service Sitionix
   description: API specification for Forge AI service
-  version: 0.0.3
+  version: 0.0.4
   contact:
     name: APP Sitionix
 servers:
@@ -15,6 +15,8 @@ paths:
     $ref: './paths/v1/forge-ai-start.yml'
   /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/analyzer/complete:
     $ref: './paths/v1/forge-ai-complete-analyzer-lane.yml'
+  /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/architect/complete:
+    $ref: './paths/v1/forge-ai-complete-architect-lane.yml'
 components:
   securitySchemes:
     bearerAuth:
@@ -35,6 +37,26 @@ components:
       $ref: './schemas/v1/forgeai/analyzer-qa-lead-handoff-dto.yml#/AnalyzerQaLeadHandoffDTO'
     CompleteAnalyzerLaneResponseDTO:
       $ref: './schemas/v1/forgeai/complete-analyzer-lane-response-dto.yml#/CompleteAnalyzerLaneResponseDTO'
+    CompleteArchitectLaneRequest:
+      $ref: './schemas/v1/forgeai/complete-architect-lane-request.yml#/CompleteArchitectLaneRequest'
+    ArchitectImplementationHandoff:
+      $ref: './schemas/v1/forgeai/architect-implementation-handoff.yml#/ArchitectImplementationHandoff'
+    ArchitectApiRequest:
+      $ref: './schemas/v1/forgeai/architect-api-request.yml#/ArchitectApiRequest'
+    ArchitectApiOperation:
+      $ref: './schemas/v1/forgeai/architect-api-operation.yml#/ArchitectApiOperation'
+    ArchitectApiParameter:
+      $ref: './schemas/v1/forgeai/architect-api-parameter.yml#/ArchitectApiParameter'
+    ArchitectApiPayloadShape:
+      $ref: './schemas/v1/forgeai/architect-api-payload-shape.yml#/ArchitectApiPayloadShape'
+    ArchitectApiField:
+      $ref: './schemas/v1/forgeai/architect-api-field.yml#/ArchitectApiField'
+    ArchitectEventRequest:
+      $ref: './schemas/v1/forgeai/architect-event-request.yml#/ArchitectEventRequest'
+    ArchitectEventPayloadField:
+      $ref: './schemas/v1/forgeai/architect-event-payload-field.yml#/ArchitectEventPayloadField'
+    CompleteArchitectLaneResponse:
+      $ref: './schemas/v1/forgeai/complete-architect-lane-response.yml#/CompleteArchitectLaneResponse'
     AgentDTO:
       $ref: './schemas/shared/agent-dto.yml#/AgentDTO'
     ErrorDTO:

--- a/apis/fgaisox/rest/paths/v1/forge-ai-complete-analyzer-lane.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-complete-analyzer-lane.yml
@@ -2,7 +2,7 @@ post:
   tags:
     - ForgeAI
   summary: Complete analyzer lane
-  operationId: completeAnalyzerLane
+  operationId: endpoint
   parameters:
     - name: ticketId
       in: path

--- a/apis/fgaisox/rest/paths/v1/forge-ai-complete-analyzer-lane.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-complete-analyzer-lane.yml
@@ -2,7 +2,7 @@ post:
   tags:
     - ForgeAI
   summary: Complete analyzer lane
-  operationId: endpoint
+  operationId: completeAnalyzerLane
   parameters:
     - name: ticketId
       in: path

--- a/apis/fgaisox/rest/paths/v1/forge-ai-complete-architect-lane.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-complete-architect-lane.yml
@@ -1,0 +1,57 @@
+post:
+  tags:
+    - ForgeAI
+  summary: Complete architect lane
+  operationId: completeArchitectLane
+  parameters:
+    - name: ticketId
+      in: path
+      required: true
+      description: Forge AI ticket identifier.
+      schema:
+        type: string
+        format: uuid
+    - name: laneId
+      in: path
+      required: true
+      description: Source ARCHITECT lane identifier.
+      schema:
+        type: string
+        format: uuid
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/CompleteArchitectLaneRequest'
+  responses:
+    '200':
+      description: Architect lane completion accepted.
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/CompleteArchitectLaneResponse'
+    '400':
+      description: Validation failed (VALIDATION_FAILED).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      description: Ticket or lane not found (TICKET_NOT_FOUND, LANE_NOT_FOUND).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '409':
+      description: Invalid lane state/agent (INVALID_LANE_AGENT, INVALID_LANE_STATE).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/fgaisox/rest/schemas/v1/forgeai/architect-api-field.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/architect-api-field.yml
@@ -1,0 +1,19 @@
+ArchitectApiField:
+  type: object
+  required:
+    - name
+    - required
+    - type
+    - description
+  properties:
+    name:
+      type: string
+      minLength: 1
+    required:
+      type: boolean
+    type:
+      type: string
+      minLength: 1
+      example: string
+    description:
+      type: string

--- a/apis/fgaisox/rest/schemas/v1/forgeai/architect-api-operation.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/architect-api-operation.yml
@@ -1,0 +1,34 @@
+ArchitectApiOperation:
+  type: object
+  required:
+    - intent
+    - method
+    - path
+    - parameters
+    - request
+    - response
+  properties:
+    intent:
+      type: string
+      minLength: 1
+      example: create agent action record
+    method:
+      type: string
+      enum:
+        - GET
+        - POST
+        - PUT
+        - PATCH
+        - DELETE
+    path:
+      type: string
+      minLength: 1
+      example: /api/v1/agent-actions
+    parameters:
+      type: array
+      items:
+        $ref: './architect-api-parameter.yml#/ArchitectApiParameter'
+    request:
+      $ref: './architect-api-payload-shape.yml#/ArchitectApiPayloadShape'
+    response:
+      $ref: './architect-api-payload-shape.yml#/ArchitectApiPayloadShape'

--- a/apis/fgaisox/rest/schemas/v1/forgeai/architect-api-parameter.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/architect-api-parameter.yml
@@ -1,0 +1,27 @@
+ArchitectApiParameter:
+  type: object
+  required:
+    - name
+    - in
+    - required
+    - type
+    - description
+  properties:
+    name:
+      type: string
+      minLength: 1
+    in:
+      type: string
+      enum:
+        - path
+        - query
+        - header
+        - cookie
+    required:
+      type: boolean
+    type:
+      type: string
+      minLength: 1
+      example: string
+    description:
+      type: string

--- a/apis/fgaisox/rest/schemas/v1/forgeai/architect-api-payload-shape.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/architect-api-payload-shape.yml
@@ -1,0 +1,9 @@
+ArchitectApiPayloadShape:
+  type: object
+  required:
+    - fields
+  properties:
+    fields:
+      type: array
+      items:
+        $ref: './architect-api-field.yml#/ArchitectApiField'

--- a/apis/fgaisox/rest/schemas/v1/forgeai/architect-api-request.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/architect-api-request.yml
@@ -1,0 +1,35 @@
+ArchitectApiRequest:
+  type: object
+  required:
+    - required
+    - reason
+    - scope
+    - summary
+    - operations
+    - consumers
+    - notes
+  properties:
+    required:
+      type: boolean
+      description: Whether API contract work is required.
+    reason:
+      type: string
+      minLength: 1
+    scope:
+      type: string
+      minLength: 1
+    summary:
+      type: string
+      minLength: 1
+    operations:
+      type: array
+      items:
+        $ref: './architect-api-operation.yml#/ArchitectApiOperation'
+    consumers:
+      type: array
+      items:
+        type: string
+    notes:
+      type: array
+      items:
+        type: string

--- a/apis/fgaisox/rest/schemas/v1/forgeai/architect-event-payload-field.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/architect-event-payload-field.yml
@@ -1,0 +1,18 @@
+ArchitectEventPayloadField:
+  type: object
+  required:
+    - name
+    - required
+    - type
+    - description
+  properties:
+    name:
+      type: string
+      minLength: 1
+    required:
+      type: boolean
+    type:
+      type: string
+      minLength: 1
+    description:
+      type: string

--- a/apis/fgaisox/rest/schemas/v1/forgeai/architect-event-request.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/architect-event-request.yml
@@ -1,0 +1,40 @@
+ArchitectEventRequest:
+  type: object
+  required:
+    - required
+    - reason
+    - scope
+    - summary
+    - eventName
+    - payloadFields
+    - consumers
+    - notes
+  properties:
+    required:
+      type: boolean
+      description: Whether event contract work is required.
+    reason:
+      type: string
+      minLength: 1
+    scope:
+      type: string
+      minLength: 1
+    summary:
+      type: string
+      minLength: 1
+    eventName:
+      type: string
+      nullable: true
+      description: Event name when event work is required.
+    payloadFields:
+      type: array
+      items:
+        $ref: './architect-event-payload-field.yml#/ArchitectEventPayloadField'
+    consumers:
+      type: array
+      items:
+        type: string
+    notes:
+      type: array
+      items:
+        type: string

--- a/apis/fgaisox/rest/schemas/v1/forgeai/architect-implementation-handoff.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/architect-implementation-handoff.yml
@@ -1,0 +1,50 @@
+ArchitectImplementationHandoff:
+  type: object
+  required:
+    - task
+    - scope
+    - summary
+    - requirements
+    - constraints
+    - nonGoals
+    - architectureDecision
+    - dependencies
+    - acceptanceNotes
+    - risks
+  properties:
+    task:
+      type: string
+      minLength: 1
+    scope:
+      type: string
+      minLength: 1
+    summary:
+      type: string
+      minLength: 1
+    requirements:
+      type: array
+      items:
+        type: string
+    constraints:
+      type: array
+      items:
+        type: string
+    nonGoals:
+      type: array
+      items:
+        type: string
+    architectureDecision:
+      type: string
+      minLength: 1
+    dependencies:
+      type: array
+      items:
+        type: string
+    acceptanceNotes:
+      type: array
+      items:
+        type: string
+    risks:
+      type: array
+      items:
+        type: string

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-architect-lane-request.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-architect-lane-request.yml
@@ -1,0 +1,17 @@
+CompleteArchitectLaneRequest:
+  type: object
+  required:
+    - summary
+    - implementationHandoff
+    - apiRequest
+    - eventRequest
+  properties:
+    summary:
+      type: string
+      minLength: 1
+    implementationHandoff:
+      $ref: './architect-implementation-handoff.yml#/ArchitectImplementationHandoff'
+    apiRequest:
+      $ref: './architect-api-request.yml#/ArchitectApiRequest'
+    eventRequest:
+      $ref: './architect-event-request.yml#/ArchitectEventRequest'

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-architect-lane-response.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-architect-lane-response.yml
@@ -1,0 +1,16 @@
+CompleteArchitectLaneResponse:
+  type: object
+  required:
+    - ticketId
+    - laneId
+    - laneStatus
+  properties:
+    ticketId:
+      type: string
+      format: uuid
+    laneId:
+      type: string
+      format: uuid
+    laneStatus:
+      type: string
+      example: DONE


### PR DESCRIPTION
## Summary
- add OpenAPI endpoint POST /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/architect/complete
- add completeArchitectLane operation contract with request/response schemas
- add architect handoff, API request, API operation, API payload, and event request schemas
- bump fgaisox API version from 0.0.3 to 0.0.4 in both openapi and metadata

## Validation
- ARTIFACT_ID=app-afesox-fgaisox-api-first-local VERSION=0.0.4 NAME=fgaisox mvn -q -Papi-first -Dproject.version=0.0.4 -DskipTests generate-sources
