### PR TITLE
[SITIONIX-31] - add API lane completion API-first contract

### DIFF
--- a/apis/fgaisox/rest/metadata.yml
+++ b/apis/fgaisox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.4
+  version: 0.0.5
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Forge AI Service Sitionix
   description: API specification for Forge AI service
-  version: 0.0.4
+  version: 0.0.5
   contact:
     name: APP Sitionix
 servers:
@@ -17,6 +17,8 @@ paths:
     $ref: './paths/v1/forge-ai-complete-analyzer-lane.yml'
   /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/architect/complete:
     $ref: './paths/v1/forge-ai-complete-architect-lane.yml'
+  /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/api/complete:
+    $ref: './paths/v1/forge-ai-complete-api-lane.yml'
 components:
   securitySchemes:
     bearerAuth:
@@ -57,6 +59,14 @@ components:
       $ref: './schemas/v1/forgeai/architect-event-payload-field.yml#/ArchitectEventPayloadField'
     CompleteArchitectLaneResponse:
       $ref: './schemas/v1/forgeai/complete-architect-lane-response.yml#/CompleteArchitectLaneResponse'
+    CompleteApiLaneRequest:
+      $ref: './schemas/v1/forgeai/complete-api-lane-request.yml#/CompleteApiLaneRequest'
+    ApiLaneContractResult:
+      $ref: './schemas/v1/forgeai/api-lane-contract-result.yml#/ApiLaneContractResult'
+    ApiLaneGeneratedArtifact:
+      $ref: './schemas/v1/forgeai/api-lane-generated-artifact.yml#/ApiLaneGeneratedArtifact'
+    CompleteApiLaneResponse:
+      $ref: './schemas/v1/forgeai/complete-api-lane-response.yml#/CompleteApiLaneResponse'
     AgentDTO:
       $ref: './schemas/shared/agent-dto.yml#/AgentDTO'
     ErrorDTO:

--- a/apis/fgaisox/rest/paths/v1/forge-ai-complete-analyzer-lane.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-complete-analyzer-lane.yml
@@ -2,7 +2,7 @@ post:
   tags:
     - ForgeAI
   summary: Complete analyzer lane
-  operationId: completeAnalyzerLane
+  operationId: endpoint
   parameters:
     - name: ticketId
       in: path

--- a/apis/fgaisox/rest/paths/v1/forge-ai-complete-analyzer-lane.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-complete-analyzer-lane.yml
@@ -2,7 +2,7 @@ post:
   tags:
     - ForgeAI
   summary: Complete analyzer lane
-  operationId: endpoint
+  operationId: completeAnalyzerLane
   parameters:
     - name: ticketId
       in: path

--- a/apis/fgaisox/rest/paths/v1/forge-ai-complete-api-lane.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-complete-api-lane.yml
@@ -1,0 +1,57 @@
+post:
+  tags:
+    - ForgeAI
+  summary: Complete API lane
+  operationId: completeApiLane
+  parameters:
+    - name: ticketId
+      in: path
+      required: true
+      description: Forge AI ticket identifier.
+      schema:
+        type: string
+        format: uuid
+    - name: laneId
+      in: path
+      required: true
+      description: Source API lane identifier.
+      schema:
+        type: string
+        format: uuid
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/CompleteApiLaneRequest'
+  responses:
+    '200':
+      description: API lane completion accepted.
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/CompleteApiLaneResponse'
+    '400':
+      description: Validation failed (VALIDATION_FAILED).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      description: Ticket or lane not found (TICKET_NOT_FOUND, LANE_NOT_FOUND).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '409':
+      description: Invalid lane state/agent (INVALID_LANE_AGENT, INVALID_LANE_STATE).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/fgaisox/rest/schemas/v1/forgeai/api-lane-contract-result.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/api-lane-contract-result.yml
@@ -1,0 +1,57 @@
+ApiLaneContractResult:
+  type: object
+  required:
+    - summary
+    - operationId
+    - method
+    - path
+    - artifacts
+    - notes
+  properties:
+    summary:
+      type: string
+      minLength: 1
+      description: Human-readable summary of this API contract result.
+      example: Create agent action record operation.
+    operationId:
+      type: string
+      minLength: 1
+      description: OpenAPI operationId for the generated or updated operation.
+      example: createAgentAction
+    method:
+      type: string
+      description: HTTP method of the operation.
+      enum:
+        - GET
+        - POST
+        - PUT
+        - PATCH
+        - DELETE
+      example: POST
+    path:
+      type: string
+      minLength: 1
+      description: HTTP path of the operation.
+      example: /api/v1/agent-actions
+    clientClass:
+      type: string
+      description: Generated client/API class associated with this operation, if available. Use empty string when not applicable or unknown.
+      example: AgentActionsApi
+    requestDto:
+      type: string
+      description: Generated request DTO/schema class for this operation, if available. Use empty string when operation has no request DTO or it is unknown.
+      example: CreateAgentActionRequestDTO
+    responseDto:
+      type: string
+      description: Generated response DTO/schema class for this operation, if available. Use empty string when operation has no response DTO or it is unknown.
+      example: CreateAgentActionResponseDTO
+    artifacts:
+      type: array
+      description: Generated artifacts required to implement or consume this operation.
+      items:
+        $ref: './api-lane-generated-artifact.yml#/ApiLaneGeneratedArtifact'
+    notes:
+      type: array
+      description: Operation-level notes for downstream implementation agents.
+      items:
+        type: string

--- a/apis/fgaisox/rest/schemas/v1/forgeai/api-lane-generated-artifact.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/api-lane-generated-artifact.yml
@@ -1,0 +1,57 @@
+ApiLaneGeneratedArtifact:
+  type: object
+  required:
+    - kind
+    - role
+    - version
+    - dependency
+  properties:
+    kind:
+      type: string
+      description: Artifact ecosystem/type.
+      enum:
+        - MAVEN
+        - NPM
+        - OTHER
+      example: MAVEN
+    role:
+      type: string
+      description: Role of the generated artifact in downstream implementation.
+      enum:
+        - API_FIRST
+        - CLIENT
+        - FRONTEND_CONTRACT
+        - OTHER
+      example: API_FIRST
+    groupId:
+      type: string
+      description: Maven groupId. Empty or omitted for non-Maven artifacts.
+      example: com.afesox
+    artifactId:
+      type: string
+      description: Maven artifactId. Empty or omitted for non-Maven artifacts.
+      example: app-afesox-atmssox-api-first-sitionix-135-unstable
+    packageName:
+      type: string
+      description: NPM package name or generated Java package name when useful. Empty or omitted if not applicable.
+      example: com.app_afesox.atmssox.api_first
+    version:
+      type: string
+      minLength: 1
+      description: Generated artifact version.
+      example: 0.0.26
+    dependency:
+      type: string
+      minLength: 1
+      description: Exact dependency/import snippet produced by generation workflow. Downstream agents must use this value directly instead of reconstructing it.
+      example: |
+        <dependency>
+          <groupId>com.afesox</groupId>
+          <artifactId>app-afesox-atmssox-api-first-sitionix-135-unstable</artifactId>
+          <version>0.0.26</version>
+        </dependency>
+    notes:
+      type: array
+      description: Artifact-specific notes.
+      items:
+        type: string

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-api-lane-request.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-api-lane-request.yml
@@ -1,0 +1,22 @@
+CompleteApiLaneRequest:
+  type: object
+  required:
+    - summary
+    - contracts
+    - notes
+  properties:
+    summary:
+      type: string
+      minLength: 1
+      description: Short summary of API contract work completed by the API lane.
+      example: API contracts generated for agent action record creation.
+    contracts:
+      type: array
+      description: List of generated or updated contract results. Each item groups operation metadata with the generated artifacts needed by downstream implementers.
+      items:
+        $ref: './api-lane-contract-result.yml#/ApiLaneContractResult'
+    notes:
+      type: array
+      description: Additional API-lane level notes that apply to all contract results.
+      items:
+        type: string

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-api-lane-response.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-api-lane-response.yml
@@ -1,0 +1,19 @@
+CompleteApiLaneResponse:
+  type: object
+  required:
+    - ticketId
+    - laneId
+    - laneStatus
+  properties:
+    ticketId:
+      type: string
+      format: uuid
+      description: Forge AI ticket id.
+    laneId:
+      type: string
+      format: uuid
+      description: Completed API lane id.
+    laneStatus:
+      type: string
+      description: Resulting API lane status.
+      example: DONE


### PR DESCRIPTION
## Summary
- add OpenAPI endpoint POST /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/api/complete
- add completeApiLane request/response schemas
- add ApiLaneContractResult and ApiLaneGeneratedArtifact schemas
- bump fgaisox API version from 0.0.4 to 0.0.5 in both openapi and metadata

## Validation
- ARTIFACT_ID=app-afesox-fgaisox-api-first-local VERSION=0.0.5 NAME=fgaisox mvn -q -Papi-first -Dproject.version=0.0.5 -DskipTests generate-sources
