### PR TITLE
[SITIONIX-4] - add scope to api lane contract result

### DIFF
--- a/apis/atmssox/rest/metadata.yml
+++ b/apis/atmssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.26
+  version: 0.0.27
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/atmssox/rest/openapi.yml
+++ b/apis/atmssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Automation Service Sitionix
   description: API specification for automation service
-  version: 0.0.26
+  version: 0.0.27
   contact:
     name: APP Sitionix
 servers:
@@ -17,6 +17,8 @@ tags:
 paths:
   /api/v1/agents:
     $ref: './paths/v1/agents.yml'
+  /api/v1/agent-actions:
+    $ref: './paths/v1/agent-actions.yml'
   /api/v1/agent-projects:
     $ref: './paths/v1/agent-projects.yml'
   /api/v1/agent-projects/{projectId}:
@@ -65,6 +67,8 @@ components:
   schemas:
     CreateAgentRequestDTO:
       $ref: './schemas/v1/agent/create-agent-request-dto.yml#/CreateAgentRequestDTO'
+    CreateAgentActionRequestDTO:
+      $ref: './schemas/v1/agent/create-agent-action-request-dto.yml#/CreateAgentActionRequestDTO'
     CreateAgentProjectRequestDTO:
       $ref: './schemas/v1/agent/create-agent-project-request-dto.yml#/CreateAgentProjectRequestDTO'
     PatchAgentRequestDTO:
@@ -75,6 +79,8 @@ components:
       $ref: './schemas/v1/agent/add-agent-to-project-request-dto.yml#/AddAgentToProjectRequestDTO'
     AgentDTO:
       $ref: './schemas/v1/agent/agent-dto.yml#/AgentDTO'
+    AgentActionDTO:
+      $ref: './schemas/v1/agent/agent-action-dto.yml#/AgentActionDTO'
     AgentProjectDTO:
       $ref: './schemas/v1/agent/agent-project-dto.yml#/AgentProjectDTO'
     AgentProjectsPageResponseDTO:

--- a/apis/atmssox/rest/paths/v1/agent-actions.yml
+++ b/apis/atmssox/rest/paths/v1/agent-actions.yml
@@ -1,0 +1,30 @@
+post:
+  tags:
+    - Agent
+  operationId: createAgentAction
+  summary: Create agent action
+  description: >
+    Creates a new agent action and returns the persisted representation.
+  security:
+    - bearerAuth: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/CreateAgentActionRequestDTO'
+  responses:
+    '201':
+      description: Agent action created
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/AgentActionDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/atmssox/rest/schemas/v1/agent/agent-action-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/agent-action-dto.yml
@@ -1,0 +1,31 @@
+AgentActionDTO:
+  title: AgentActionDTO
+  type: object
+  additionalProperties: false
+  required:
+    - id
+    - title
+    - status
+    - createdAt
+  properties:
+    id:
+      type: string
+      description: Created agent action identifier.
+    title:
+      type: string
+      description: Agent action title.
+    description:
+      type: string
+      description: Agent action description.
+    metadata:
+      type: object
+      description: Agent action metadata payload.
+      additionalProperties: true
+    status:
+      type: string
+      description: Current agent action status.
+      example: CREATED
+    createdAt:
+      type: string
+      format: date-time
+      description: Agent action creation timestamp (UTC).

--- a/apis/atmssox/rest/schemas/v1/agent/create-agent-action-request-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/create-agent-action-request-dto.yml
@@ -1,0 +1,21 @@
+CreateAgentActionRequestDTO:
+  title: CreateAgentActionRequestDTO
+  type: object
+  additionalProperties: false
+  required:
+    - title
+  properties:
+    title:
+      type: string
+      minLength: 1
+      pattern: ".*\\S.*"
+      description: Agent action title.
+      example: Validate pull request checks
+    description:
+      type: string
+      description: Optional agent action description.
+      example: Ensure CI and contract checks are green before approval.
+    metadata:
+      type: object
+      description: Optional metadata payload forwarded as object.
+      additionalProperties: true

--- a/apis/bffssox/rest/metadata.yml
+++ b/apis/bffssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.40
+  version: 0.0.41
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/bffssox/rest/openapi.yml
+++ b/apis/bffssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Backend for Frontend Sitionix
   description: API specification for the BFF authentication facade
-  version: 0.0.40
+  version: 0.0.41
   contact:
     name: APP Sitionix
 servers:
@@ -32,6 +32,8 @@ paths:
     $ref: './paths/v1/sites-overview.yml'
   /api/v1/agents:
     $ref: './paths/v1/agents.yml'
+  /api/v1/agent-actions:
+    $ref: './paths/v1/agent-actions.yml'
   /api/v1/agent-projects:
     $ref: './paths/v1/agent-projects.yml'
   /api/v1/agent-projects/{projectId}:
@@ -102,6 +104,8 @@ components:
       $ref: './schemas/v1/site/create-site-response-dto.yml#/CreateSiteResponseDTO'
     CreateAgentRequestDTO:
       $ref: './schemas/v1/agent/create-agent-request-dto.yml#/CreateAgentRequestDTO'
+    CreateAgentActionRequestDTO:
+      $ref: './schemas/v1/agent/create-agent-action-request-dto.yml#/CreateAgentActionRequestDTO'
     CreateAgentProjectRequestDTO:
       $ref: './schemas/v1/agent/create-agent-project-request-dto.yml#/CreateAgentProjectRequestDTO'
     PatchAgentRequestDTO:
@@ -112,6 +116,8 @@ components:
       $ref: './schemas/v1/agent/add-agent-to-project-request-dto.yml#/AddAgentToProjectRequestDTO'
     AgentDTO:
       $ref: './schemas/v1/agent/agent-dto.yml#/AgentDTO'
+    AgentActionDTO:
+      $ref: './schemas/v1/agent/agent-action-dto.yml#/AgentActionDTO'
     AgentProjectDTO:
       $ref: './schemas/v1/agent/agent-project-dto.yml#/AgentProjectDTO'
     AgentProjectsPageResponseDTO:

--- a/apis/bffssox/rest/paths/v1/agent-actions.yml
+++ b/apis/bffssox/rest/paths/v1/agent-actions.yml
@@ -1,0 +1,30 @@
+post:
+  tags:
+    - Agent
+  operationId: createAgentAction
+  summary: Create agent action
+  description: >
+    Creates a new agent action and returns the persisted representation.
+  security:
+    - bearerAuth: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/CreateAgentActionRequestDTO'
+  responses:
+    '201':
+      description: Agent action created
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/AgentActionDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/bffssox/rest/schemas/v1/agent/agent-action-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agent-action-dto.yml
@@ -1,0 +1,31 @@
+AgentActionDTO:
+  title: AgentActionDTO
+  type: object
+  additionalProperties: false
+  required:
+    - id
+    - title
+    - status
+    - createdAt
+  properties:
+    id:
+      type: string
+      description: Created agent action identifier.
+    title:
+      type: string
+      description: Agent action title.
+    description:
+      type: string
+      description: Agent action description.
+    metadata:
+      type: object
+      description: Agent action metadata payload.
+      additionalProperties: true
+    status:
+      type: string
+      description: Current agent action status.
+      example: CREATED
+    createdAt:
+      type: string
+      format: date-time
+      description: Agent action creation timestamp (UTC).

--- a/apis/bffssox/rest/schemas/v1/agent/create-agent-action-request-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/create-agent-action-request-dto.yml
@@ -1,0 +1,21 @@
+CreateAgentActionRequestDTO:
+  title: CreateAgentActionRequestDTO
+  type: object
+  additionalProperties: false
+  required:
+    - title
+  properties:
+    title:
+      type: string
+      minLength: 1
+      pattern: ".*\\S.*"
+      description: Agent action title.
+      example: Validate pull request checks
+    description:
+      type: string
+      description: Optional agent action description.
+      example: Ensure CI and contract checks are green before approval.
+    metadata:
+      type: object
+      description: Optional metadata payload forwarded as object.
+      additionalProperties: true

--- a/apis/fgaisox/rest/metadata.yml
+++ b/apis/fgaisox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.5
+  version: 0.0.6
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Forge AI Service Sitionix
   description: API specification for Forge AI service
-  version: 0.0.5
+  version: 0.0.6
   contact:
     name: APP Sitionix
 servers:

--- a/apis/fgaisox/rest/schemas/v1/forgeai/api-lane-contract-result.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/api-lane-contract-result.yml
@@ -1,6 +1,7 @@
 ApiLaneContractResult:
   type: object
   required:
+    - scope
     - summary
     - operationId
     - method
@@ -8,6 +9,11 @@ ApiLaneContractResult:
     - artifacts
     - notes
   properties:
+    scope:
+      type: string
+      minLength: 1
+      description: Service scope path that owns this contract unit (for example backendforfrontendservice-sox, automationservice-sox).
+      example: backendforfrontendservice-sox
     summary:
       type: string
       minLength: 1


### PR DESCRIPTION
## Summary
- add required `scope` field to `ApiLaneContractResult`
- bump fgaisox REST version to `0.0.6`
- keep OpenAPI and metadata versions synchronized

## Files
- apis/fgaisox/rest/schemas/v1/forgeai/api-lane-contract-result.yml
- apis/fgaisox/rest/openapi.yml
- apis/fgaisox/rest/metadata.yml