### PR TITLE
[SITIONIX-4] - add scope to api lane contract result

### DIFF
--- a/apis/fgaisox/rest/metadata.yml
+++ b/apis/fgaisox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.5
+  version: 0.0.6
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Forge AI Service Sitionix
   description: API specification for Forge AI service
-  version: 0.0.5
+  version: 0.0.6
   contact:
     name: APP Sitionix
 servers:

--- a/apis/fgaisox/rest/schemas/v1/forgeai/api-lane-contract-result.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/api-lane-contract-result.yml
@@ -1,6 +1,7 @@
 ApiLaneContractResult:
   type: object
   required:
+    - scope
     - summary
     - operationId
     - method
@@ -8,6 +9,11 @@ ApiLaneContractResult:
     - artifacts
     - notes
   properties:
+    scope:
+      type: string
+      minLength: 1
+      description: Service scope path that owns this contract unit (for example backendforfrontendservice-sox, automationservice-sox).
+      example: backendforfrontendservice-sox
     summary:
       type: string
       minLength: 1


### PR DESCRIPTION
## Summary
- add required `scope` to `ApiLaneContractResult`
- bump fgaisox REST version to `0.0.6`
- sync `openapi.yml` and `metadata.yml` versions

## Files
- apis/fgaisox/rest/schemas/v1/forgeai/api-lane-contract-result.yml
- apis/fgaisox/rest/openapi.yml
- apis/fgaisox/rest/metadata.yml