### PR TITLE
[SITIONIX-1122] - add agent-actions contract for bff and automation

### DIFF
--- a/apis/atmssox/rest/metadata.yml
+++ b/apis/atmssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.26
+  version: 0.0.27
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/atmssox/rest/openapi.yml
+++ b/apis/atmssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Automation Service Sitionix
   description: API specification for automation service
-  version: 0.0.26
+  version: 0.0.27
   contact:
     name: APP Sitionix
 servers:
@@ -17,6 +17,8 @@ tags:
 paths:
   /api/v1/agents:
     $ref: './paths/v1/agents.yml'
+  /api/v1/agent-actions:
+    $ref: './paths/v1/agent-actions.yml'
   /api/v1/agent-projects:
     $ref: './paths/v1/agent-projects.yml'
   /api/v1/agent-projects/{projectId}:
@@ -65,6 +67,8 @@ components:
   schemas:
     CreateAgentRequestDTO:
       $ref: './schemas/v1/agent/create-agent-request-dto.yml#/CreateAgentRequestDTO'
+    CreateAgentActionRequestDTO:
+      $ref: './schemas/v1/agent/create-agent-action-request-dto.yml#/CreateAgentActionRequestDTO'
     CreateAgentProjectRequestDTO:
       $ref: './schemas/v1/agent/create-agent-project-request-dto.yml#/CreateAgentProjectRequestDTO'
     PatchAgentRequestDTO:
@@ -75,6 +79,8 @@ components:
       $ref: './schemas/v1/agent/add-agent-to-project-request-dto.yml#/AddAgentToProjectRequestDTO'
     AgentDTO:
       $ref: './schemas/v1/agent/agent-dto.yml#/AgentDTO'
+    AgentActionDTO:
+      $ref: './schemas/v1/agent/agent-action-dto.yml#/AgentActionDTO'
     AgentProjectDTO:
       $ref: './schemas/v1/agent/agent-project-dto.yml#/AgentProjectDTO'
     AgentProjectsPageResponseDTO:

--- a/apis/atmssox/rest/paths/v1/agent-actions.yml
+++ b/apis/atmssox/rest/paths/v1/agent-actions.yml
@@ -1,0 +1,30 @@
+post:
+  tags:
+    - Agent
+  operationId: createAgentAction
+  summary: Create agent action
+  description: >
+    Creates a new agent action with backend-controlled initial status.
+  security:
+    - bearerAuth: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/CreateAgentActionRequestDTO'
+  responses:
+    '201':
+      description: Agent action created
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/AgentActionDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/atmssox/rest/schemas/v1/agent/agent-action-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/agent-action-dto.yml
@@ -1,0 +1,32 @@
+AgentActionDTO:
+  title: AgentActionDTO
+  type: object
+  additionalProperties: false
+  required:
+    - id
+    - title
+    - status
+    - createdAt
+  properties:
+    id:
+      type: string
+      format: uuid
+      description: Created agent action identifier.
+    title:
+      type: string
+      description: Persisted action title.
+    description:
+      type: string
+      description: Persisted action description.
+    metadata:
+      type: object
+      description: Persisted metadata JSON object.
+      additionalProperties: true
+    status:
+      type: string
+      description: Initial action status assigned at creation.
+      example: CREATED
+    createdAt:
+      type: string
+      format: date-time
+      description: Creation timestamp.

--- a/apis/atmssox/rest/schemas/v1/agent/create-agent-action-request-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/create-agent-action-request-dto.yml
@@ -1,0 +1,28 @@
+CreateAgentActionRequestDTO:
+  title: CreateAgentActionRequestDTO
+  type: object
+  additionalProperties: false
+  required:
+    - title
+  properties:
+    title:
+      type: string
+      minLength: 1
+      maxLength: 120
+      pattern: ".*\\S.*"
+      description: Action title; must be non-blank.
+      example: Investigate flaky pipeline
+    description:
+      type: string
+      minLength: 1
+      maxLength: 500
+      pattern: ".*\\S.*"
+      description: Optional action description.
+      example: Re-run failed suite and collect diagnostics
+    metadata:
+      type: object
+      description: Optional JSON object metadata; non-object shapes are invalid.
+      additionalProperties: true
+      example:
+        source: workspace
+        priority: high

--- a/apis/bffssox/rest/metadata.yml
+++ b/apis/bffssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.40
+  version: 0.0.41
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/bffssox/rest/openapi.yml
+++ b/apis/bffssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Backend for Frontend Sitionix
   description: API specification for the BFF authentication facade
-  version: 0.0.40
+  version: 0.0.41
   contact:
     name: APP Sitionix
 servers:
@@ -32,6 +32,8 @@ paths:
     $ref: './paths/v1/sites-overview.yml'
   /api/v1/agents:
     $ref: './paths/v1/agents.yml'
+  /api/v1/agent-actions:
+    $ref: './paths/v1/agent-actions.yml'
   /api/v1/agent-projects:
     $ref: './paths/v1/agent-projects.yml'
   /api/v1/agent-projects/{projectId}:
@@ -102,6 +104,8 @@ components:
       $ref: './schemas/v1/site/create-site-response-dto.yml#/CreateSiteResponseDTO'
     CreateAgentRequestDTO:
       $ref: './schemas/v1/agent/create-agent-request-dto.yml#/CreateAgentRequestDTO'
+    CreateAgentActionRequestDTO:
+      $ref: './schemas/v1/agent/create-agent-action-request-dto.yml#/CreateAgentActionRequestDTO'
     CreateAgentProjectRequestDTO:
       $ref: './schemas/v1/agent/create-agent-project-request-dto.yml#/CreateAgentProjectRequestDTO'
     PatchAgentRequestDTO:
@@ -112,6 +116,8 @@ components:
       $ref: './schemas/v1/agent/add-agent-to-project-request-dto.yml#/AddAgentToProjectRequestDTO'
     AgentDTO:
       $ref: './schemas/v1/agent/agent-dto.yml#/AgentDTO'
+    AgentActionDTO:
+      $ref: './schemas/v1/agent/agent-action-dto.yml#/AgentActionDTO'
     AgentProjectDTO:
       $ref: './schemas/v1/agent/agent-project-dto.yml#/AgentProjectDTO'
     AgentProjectsPageResponseDTO:

--- a/apis/bffssox/rest/paths/v1/agent-actions.yml
+++ b/apis/bffssox/rest/paths/v1/agent-actions.yml
@@ -1,0 +1,30 @@
+post:
+  tags:
+    - Agent
+  operationId: createAgentAction
+  summary: Create agent action
+  description: >
+    Creates a new agent action by delegating creation to the upstream automation domain API.
+  security:
+    - bearerAuth: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/CreateAgentActionRequestDTO'
+  responses:
+    '201':
+      description: Agent action created
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/AgentActionDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/bffssox/rest/schemas/v1/agent/agent-action-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agent-action-dto.yml
@@ -1,0 +1,32 @@
+AgentActionDTO:
+  title: AgentActionDTO
+  type: object
+  additionalProperties: false
+  required:
+    - id
+    - title
+    - status
+    - createdAt
+  properties:
+    id:
+      type: string
+      format: uuid
+      description: Created action identifier returned by upstream domain backend.
+    title:
+      type: string
+      description: Created action title from upstream response contract.
+    description:
+      type: string
+      description: Created action description from upstream response contract.
+    metadata:
+      type: object
+      description: Created action metadata from upstream response contract.
+      additionalProperties: true
+    status:
+      type: string
+      description: Backend-controlled action status returned to Workspace client.
+      example: CREATED
+    createdAt:
+      type: string
+      format: date-time
+      description: Creation timestamp from upstream response contract.

--- a/apis/bffssox/rest/schemas/v1/agent/create-agent-action-request-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/create-agent-action-request-dto.yml
@@ -1,0 +1,28 @@
+CreateAgentActionRequestDTO:
+  title: CreateAgentActionRequestDTO
+  type: object
+  additionalProperties: false
+  required:
+    - title
+  properties:
+    title:
+      type: string
+      minLength: 1
+      maxLength: 120
+      pattern: ".*\\S.*"
+      description: Action title; required and forwarded unchanged to upstream domain create contract.
+      example: Investigate flaky pipeline
+    description:
+      type: string
+      minLength: 1
+      maxLength: 500
+      pattern: ".*\\S.*"
+      description: Optional action description forwarded unchanged when present.
+      example: Re-run failed suite and collect diagnostics
+    metadata:
+      type: object
+      description: Optional metadata object forwarded unchanged with contract-defined shape/type semantics.
+      additionalProperties: true
+      example:
+        source: workspace
+        priority: high


### PR DESCRIPTION
## Summary
- add POST /api/v1/agent-actions contract to bffssox and atmssox
- add create request and action response DTO schemas
- bump bffssox and atmssox REST versions with synchronized metadata/openapi

## Why
Align Workspace-facing BFF and automation synchronous create-agent-action contracts with controlled 400/403 mappings.