### PR TITLE
[SITIONIX-6] - add implement-be lane completion endpoint contract

### DIFF
--- a/apis/fgaisox/rest/metadata.yml
+++ b/apis/fgaisox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.6
+  version: 0.0.7
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Forge AI Service Sitionix
   description: API specification for Forge AI service
-  version: 0.0.6
+  version: 0.0.7
   contact:
     name: APP Sitionix
 servers:
@@ -19,6 +19,8 @@ paths:
     $ref: './paths/v1/forge-ai-complete-architect-lane.yml'
   /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/api/complete:
     $ref: './paths/v1/forge-ai-complete-api-lane.yml'
+  /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/implement-be/complete:
+    $ref: './paths/v1/forge-ai-complete-implement-be-lane.yml'
 components:
   securitySchemes:
     bearerAuth:
@@ -67,6 +69,16 @@ components:
       $ref: './schemas/v1/forgeai/api-lane-generated-artifact.yml#/ApiLaneGeneratedArtifact'
     CompleteApiLaneResponse:
       $ref: './schemas/v1/forgeai/complete-api-lane-response.yml#/CompleteApiLaneResponse'
+    CompleteImplementBeLaneRequest:
+      $ref: './schemas/v1/forgeai/complete-implement-be-lane-request.yml#/CompleteImplementBeLaneRequest'
+    ImplementBeChangedFile:
+      $ref: './schemas/v1/forgeai/implement-be-changed-file.yml#/ImplementBeChangedFile'
+    ImplementBeIntegrationFlow:
+      $ref: './schemas/v1/forgeai/implement-be-integration-flow.yml#/ImplementBeIntegrationFlow'
+    ImplementBePersistenceChange:
+      $ref: './schemas/v1/forgeai/implement-be-persistence-change.yml#/ImplementBePersistenceChange'
+    CompleteImplementBeLaneResponse:
+      $ref: './schemas/v1/forgeai/complete-implement-be-lane-response.yml#/CompleteImplementBeLaneResponse'
     AgentDTO:
       $ref: './schemas/shared/agent-dto.yml#/AgentDTO'
     ErrorDTO:

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -69,16 +69,16 @@ components:
       $ref: './schemas/v1/forgeai/api-lane-generated-artifact.yml#/ApiLaneGeneratedArtifact'
     CompleteApiLaneResponse:
       $ref: './schemas/v1/forgeai/complete-api-lane-response.yml#/CompleteApiLaneResponse'
-    CompleteImplementBeLaneRequest:
-      $ref: './schemas/v1/forgeai/complete-implement-be-lane-request.yml#/CompleteImplementBeLaneRequest'
-    ImplementBeChangedFile:
-      $ref: './schemas/v1/forgeai/implement-be-changed-file.yml#/ImplementBeChangedFile'
-    ImplementBeIntegrationFlow:
-      $ref: './schemas/v1/forgeai/implement-be-integration-flow.yml#/ImplementBeIntegrationFlow'
-    ImplementBePersistenceChange:
-      $ref: './schemas/v1/forgeai/implement-be-persistence-change.yml#/ImplementBePersistenceChange'
-    CompleteImplementBeLaneResponse:
-      $ref: './schemas/v1/forgeai/complete-implement-be-lane-response.yml#/CompleteImplementBeLaneResponse'
+    CompleteImplementBeLaneRequestDTO:
+      $ref: './schemas/v1/forgeai/complete-implement-be-lane-request.yml#/CompleteImplementBeLaneRequestDTO'
+    ImplementBeChangedFileDTO:
+      $ref: './schemas/v1/forgeai/implement-be-changed-file.yml#/ImplementBeChangedFileDTO'
+    ImplementBeIntegrationFlowDTO:
+      $ref: './schemas/v1/forgeai/implement-be-integration-flow.yml#/ImplementBeIntegrationFlowDTO'
+    ImplementBePersistenceChangeDTO:
+      $ref: './schemas/v1/forgeai/implement-be-persistence-change.yml#/ImplementBePersistenceChangeDTO'
+    CompleteImplementBeLaneResponseDTO:
+      $ref: './schemas/v1/forgeai/complete-implement-be-lane-response.yml#/CompleteImplementBeLaneResponseDTO'
     AgentDTO:
       $ref: './schemas/shared/agent-dto.yml#/AgentDTO'
     ErrorDTO:

--- a/apis/fgaisox/rest/paths/v1/forge-ai-complete-implement-be-lane.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-complete-implement-be-lane.yml
@@ -1,0 +1,55 @@
+post:
+  tags:
+    - ForgeAI
+  summary: Complete backend implementation lane
+  operationId: completeImplementBeLane
+  parameters:
+    - name: ticketId
+      in: path
+      required: true
+      description: Forge AI ticket identifier (for example, SITIONIX-135).
+      schema:
+        type: string
+    - name: laneId
+      in: path
+      required: true
+      description: Backend implementer lane identifier (for example, implement-be.automationservice-sox).
+      schema:
+        type: string
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/CompleteImplementBeLaneRequest'
+  responses:
+    '200':
+      description: Backend implementation lane completion accepted.
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/CompleteImplementBeLaneResponse'
+    '400':
+      description: Validation failed (VALIDATION_FAILED).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      description: Ticket or lane not found (TICKET_NOT_FOUND, LANE_NOT_FOUND).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '409':
+      description: Invalid lane state/agent/scope (INVALID_LANE_AGENT, INVALID_LANE_STATE, LANE_SCOPE_MISMATCH).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/fgaisox/rest/paths/v1/forge-ai-complete-implement-be-lane.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-complete-implement-be-lane.yml
@@ -21,14 +21,14 @@ post:
     content:
       application/json:
         schema:
-          $ref: '../../openapi.yml#/components/schemas/CompleteImplementBeLaneRequest'
+          $ref: '../../openapi.yml#/components/schemas/CompleteImplementBeLaneRequestDTO'
   responses:
     '200':
       description: Backend implementation lane completion accepted.
       content:
         application/json:
           schema:
-            $ref: '../../openapi.yml#/components/schemas/CompleteImplementBeLaneResponse'
+            $ref: '../../openapi.yml#/components/schemas/CompleteImplementBeLaneResponseDTO'
     '400':
       description: Validation failed (VALIDATION_FAILED).
       content:

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-implement-be-lane-request.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-implement-be-lane-request.yml
@@ -1,4 +1,4 @@
-CompleteImplementBeLaneRequest:
+CompleteImplementBeLaneRequestDTO:
   type: object
   additionalProperties: false
   required:
@@ -23,14 +23,14 @@ CompleteImplementBeLaneRequest:
       minItems: 1
       description: Changed backend files for downstream Unit Test lane input.
       items:
-        $ref: './implement-be-changed-file.yml#/ImplementBeChangedFile'
+        $ref: './implement-be-changed-file.yml#/ImplementBeChangedFileDTO'
     integrationFlows:
       type: array
       description: Implemented or changed integration boundaries (REST/internal flows) for downstream Integration Test lane input.
       items:
-        $ref: './implement-be-integration-flow.yml#/ImplementBeIntegrationFlow'
+        $ref: './implement-be-integration-flow.yml#/ImplementBeIntegrationFlowDTO'
     persistenceChanges:
       type: array
       description: Implemented persistence/data-model changes for downstream Integration Test lane input.
       items:
-        $ref: './implement-be-persistence-change.yml#/ImplementBePersistenceChange'
+        $ref: './implement-be-persistence-change.yml#/ImplementBePersistenceChangeDTO'

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-implement-be-lane-request.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-implement-be-lane-request.yml
@@ -1,0 +1,36 @@
+CompleteImplementBeLaneRequest:
+  type: object
+  additionalProperties: false
+  required:
+    - scope
+    - summary
+    - changedFiles
+    - integrationFlows
+    - persistenceChanges
+  properties:
+    scope:
+      type: string
+      minLength: 1
+      description: Service scope where backend implementation was done; must match lane scope and configured runtime scope.
+      example: automationservice-sox
+    summary:
+      type: string
+      minLength: 1
+      description: Compact human-readable summary of backend implementation result for runtime/ticket state.
+      example: Implemented backend support for agent action creation.
+    changedFiles:
+      type: array
+      minItems: 1
+      description: Changed backend files for downstream Unit Test lane input.
+      items:
+        $ref: './implement-be-changed-file.yml#/ImplementBeChangedFile'
+    integrationFlows:
+      type: array
+      description: Implemented or changed integration boundaries (REST/internal flows) for downstream Integration Test lane input.
+      items:
+        $ref: './implement-be-integration-flow.yml#/ImplementBeIntegrationFlow'
+    persistenceChanges:
+      type: array
+      description: Implemented persistence/data-model changes for downstream Integration Test lane input.
+      items:
+        $ref: './implement-be-persistence-change.yml#/ImplementBePersistenceChange'

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-implement-be-lane-response.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-implement-be-lane-response.yml
@@ -1,4 +1,4 @@
-CompleteImplementBeLaneResponse:
+CompleteImplementBeLaneResponseDTO:
   type: object
   additionalProperties: false
   required:

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-implement-be-lane-response.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-implement-be-lane-response.yml
@@ -1,0 +1,20 @@
+CompleteImplementBeLaneResponse:
+  type: object
+  additionalProperties: false
+  required:
+    - ticketId
+    - laneId
+    - status
+  properties:
+    ticketId:
+      type: string
+      description: Ticket identifier for which backend implementation lane was completed.
+      example: SITIONIX-135
+    laneId:
+      type: string
+      description: Completed backend implementation lane identifier.
+      example: implement-be.automationservice-sox
+    status:
+      type: string
+      description: Resulting lane status after successful completion.
+      example: DONE

--- a/apis/fgaisox/rest/schemas/v1/forgeai/implement-be-changed-file.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/implement-be-changed-file.yml
@@ -1,4 +1,4 @@
-ImplementBeChangedFile:
+ImplementBeChangedFileDTO:
   type: object
   additionalProperties: false
   required:

--- a/apis/fgaisox/rest/schemas/v1/forgeai/implement-be-changed-file.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/implement-be-changed-file.yml
@@ -1,0 +1,17 @@
+ImplementBeChangedFile:
+  type: object
+  additionalProperties: false
+  required:
+    - path
+    - reason
+  properties:
+    path:
+      type: string
+      minLength: 1
+      description: Repository-relative file path changed by backend implementation in the declared scope.
+      example: automationservice-sox/src/main/java/com/sitionix/atmssox/application/agent/CreateAgentActionUseCase.java
+    reason:
+      type: string
+      minLength: 1
+      description: Short explanation of why this file was changed from an implementation perspective.
+      example: Added backend use case for creating agent action records.

--- a/apis/fgaisox/rest/schemas/v1/forgeai/implement-be-integration-flow.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/implement-be-integration-flow.yml
@@ -1,0 +1,47 @@
+ImplementBeIntegrationFlow:
+  type: object
+  additionalProperties: false
+  required:
+    - name
+    - summary
+  oneOf:
+    - required:
+        - method
+        - path
+    - not:
+        anyOf:
+          - required:
+              - method
+          - required:
+              - path
+  properties:
+    name:
+      type: string
+      minLength: 1
+      description: Human-readable integration flow name affected by backend implementation.
+      example: Create agent action
+    operationId:
+      type: string
+      nullable: true
+      description: OpenAPI operationId when this flow maps to an API-first operation and the id exists in the contract.
+      example: createAgentAction
+    method:
+      type: string
+      description: HTTP method for REST flow; required when the flow represents a REST endpoint.
+      enum:
+        - GET
+        - POST
+        - PUT
+        - PATCH
+        - DELETE
+      example: POST
+    path:
+      type: string
+      description: REST path for the implemented flow; required when the flow represents a REST endpoint.
+      pattern: '^/'
+      example: /api/v1/agent-actions
+    summary:
+      type: string
+      minLength: 1
+      description: Short description of what this implemented integration flow does.
+      example: Creates an agent action record through REST API.

--- a/apis/fgaisox/rest/schemas/v1/forgeai/implement-be-integration-flow.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/implement-be-integration-flow.yml
@@ -1,19 +1,9 @@
-ImplementBeIntegrationFlow:
+ImplementBeIntegrationFlowDTO:
   type: object
   additionalProperties: false
   required:
     - name
     - summary
-  oneOf:
-    - required:
-        - method
-        - path
-    - not:
-        anyOf:
-          - required:
-              - method
-          - required:
-              - path
   properties:
     name:
       type: string

--- a/apis/fgaisox/rest/schemas/v1/forgeai/implement-be-persistence-change.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/implement-be-persistence-change.yml
@@ -1,4 +1,4 @@
-ImplementBePersistenceChange:
+ImplementBePersistenceChangeDTO:
   type: object
   additionalProperties: false
   required:

--- a/apis/fgaisox/rest/schemas/v1/forgeai/implement-be-persistence-change.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/implement-be-persistence-change.yml
@@ -1,0 +1,36 @@
+ImplementBePersistenceChange:
+  type: object
+  additionalProperties: false
+  required:
+    - type
+    - name
+    - summary
+  properties:
+    type:
+      type: string
+      description: Type of persistence change introduced by backend implementation.
+      enum:
+        - TABLE_CREATED
+        - TABLE_CHANGED
+        - COLUMN_ADDED
+        - COLUMN_CHANGED
+        - COLUMN_REMOVED
+        - INDEX_ADDED
+        - INDEX_CHANGED
+        - MIGRATION_ADDED
+        - ENTITY_ADDED
+        - ENTITY_CHANGED
+        - REPOSITORY_ADDED
+        - REPOSITORY_CHANGED
+        - OTHER
+      example: TABLE_CREATED
+    name:
+      type: string
+      minLength: 1
+      description: Name of changed persistence object (for example table, column, migration, entity, repository).
+      example: agent_actions
+    summary:
+      type: string
+      minLength: 1
+      description: Short factual explanation of what persistence change was implemented and why.
+      example: Stores agent action records.


### PR DESCRIPTION
## Summary
- add POST /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/implement-be/complete
- add strict request/response schemas for BE lane completion payload
- enforce allowed root fields only via additionalProperties: false
- add enum validation for integration HTTP methods and persistence change types
- bump fgaisox API version to 0.0.7

## Notes
- this is API-first contract implementation in app-afesox
- request schema includes detailed field descriptions for downstream Codex lane consumption