### PR TITLE
[SITIONIX-7] - make implement-be ticket and lane ids uuid

### DIFF
--- a/apis/fgaisox/rest/metadata.yml
+++ b/apis/fgaisox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.7
+  version: 0.0.8
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Forge AI Service Sitionix
   description: API specification for Forge AI service
-  version: 0.0.7
+  version: 0.0.8
   contact:
     name: APP Sitionix
 servers:

--- a/apis/fgaisox/rest/paths/v1/forge-ai-complete-implement-be-lane.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-complete-implement-be-lane.yml
@@ -7,15 +7,17 @@ post:
     - name: ticketId
       in: path
       required: true
-      description: Forge AI ticket identifier (for example, SITIONIX-135).
+      description: Forge AI ticket identifier in UUID format.
       schema:
         type: string
+        format: uuid
     - name: laneId
       in: path
       required: true
-      description: Backend implementer lane identifier (for example, implement-be.automationservice-sox).
+      description: Backend implementer lane identifier in UUID format.
       schema:
         type: string
+        format: uuid
   requestBody:
     required: true
     content:

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-implement-be-lane-response.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-implement-be-lane-response.yml
@@ -8,12 +8,14 @@ CompleteImplementBeLaneResponseDTO:
   properties:
     ticketId:
       type: string
+      format: uuid
       description: Ticket identifier for which backend implementation lane was completed.
-      example: SITIONIX-135
+      example: 8f6f38ca-2f27-4c6a-a7f4-d6a1d7473f7e
     laneId:
       type: string
+      format: uuid
       description: Completed backend implementation lane identifier.
-      example: implement-be.automationservice-sox
+      example: 3c7ea31b-8660-4f89-a124-72be9d1b58f5
     status:
       type: string
       description: Resulting lane status after successful completion.


### PR DESCRIPTION
## Summary
- update Forge AI implement-be completion endpoint path params to UUID format
- update response DTO fields  and  to UUID format
- align examples/descriptions with UUID-based identifiers

## Files
- apis/fgaisox/rest/paths/v1/forge-ai-complete-implement-be-lane.yml
- apis/fgaisox/rest/schemas/v1/forgeai/complete-implement-be-lane-response.yml