### PR TITLE
[SITIONIX-8] - add QA Lead lane completion endpoint contract

### DIFF
--- a/apis/fgaisox/rest/metadata.yml
+++ b/apis/fgaisox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.8
+  version: 0.0.9
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Forge AI Service Sitionix
   description: API specification for Forge AI service
-  version: 0.0.8
+  version: 0.0.9
   contact:
     name: APP Sitionix
 servers:
@@ -21,6 +21,8 @@ paths:
     $ref: './paths/v1/forge-ai-complete-api-lane.yml'
   /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/implement-be/complete:
     $ref: './paths/v1/forge-ai-complete-implement-be-lane.yml'
+  /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/qa-lead/complete:
+    $ref: './paths/v1/forge-ai-complete-qa-lead-lane.yml'
 components:
   securitySchemes:
     bearerAuth:
@@ -79,6 +81,18 @@ components:
       $ref: './schemas/v1/forgeai/implement-be-persistence-change.yml#/ImplementBePersistenceChangeDTO'
     CompleteImplementBeLaneResponseDTO:
       $ref: './schemas/v1/forgeai/complete-implement-be-lane-response.yml#/CompleteImplementBeLaneResponseDTO'
+    CompleteQaLeadLaneRequestDTO:
+      $ref: './schemas/v1/forgeai/complete-qa-lead-lane-request-dto.yml#/CompleteQaLeadLaneRequestDTO'
+    QaLeadIntegrationTestCaseDTO:
+      $ref: './schemas/v1/forgeai/qa-lead-integration-test-case-dto.yml#/QaLeadIntegrationTestCaseDTO'
+    QaLeadIntegrationFlowDTO:
+      $ref: './schemas/v1/forgeai/qa-lead-integration-flow-dto.yml#/QaLeadIntegrationFlowDTO'
+    QaLeadDataCheckDTO:
+      $ref: './schemas/v1/forgeai/qa-lead-data-check-dto.yml#/QaLeadDataCheckDTO'
+    QaLeadUnitTestNoteDTO:
+      $ref: './schemas/v1/forgeai/qa-lead-unit-test-note-dto.yml#/QaLeadUnitTestNoteDTO'
+    CompleteQaLeadLaneResponseDTO:
+      $ref: './schemas/v1/forgeai/complete-qa-lead-lane-response-dto.yml#/CompleteQaLeadLaneResponseDTO'
     AgentDTO:
       $ref: './schemas/shared/agent-dto.yml#/AgentDTO'
     ErrorDTO:

--- a/apis/fgaisox/rest/paths/v1/forge-ai-complete-qa-lead-lane.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-complete-qa-lead-lane.yml
@@ -1,0 +1,57 @@
+post:
+  tags:
+    - ForgeAI
+  summary: Complete QA Lead lane
+  operationId: completeQaLeadLane
+  parameters:
+    - name: ticketId
+      in: path
+      required: true
+      description: Forge AI ticket identifier in UUID format.
+      schema:
+        type: string
+        format: uuid
+    - name: laneId
+      in: path
+      required: true
+      description: QA Lead lane identifier in UUID format.
+      schema:
+        type: string
+        format: uuid
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/CompleteQaLeadLaneRequestDTO'
+  responses:
+    '200':
+      description: QA Lead lane completion accepted.
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/CompleteQaLeadLaneResponseDTO'
+    '400':
+      description: Validation failed (VALIDATION_FAILED).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      description: Ticket or lane not found (TICKET_NOT_FOUND, LANE_NOT_FOUND).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '409':
+      description: Invalid lane state/agent/scope (INVALID_LANE_AGENT, INVALID_LANE_STATE, LANE_SCOPE_MISMATCH).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-qa-lead-lane-request-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-qa-lead-lane-request-dto.yml
@@ -1,0 +1,29 @@
+CompleteQaLeadLaneRequestDTO:
+  type: object
+  additionalProperties: false
+  required:
+    - scope
+    - summary
+    - integrationTestCases
+    - unitTestNotes
+  properties:
+    scope:
+      type: string
+      minLength: 1
+      description: Assigned service scope for which QA Lead prepared test context; must match lane scope.
+      example: automationservice-sox
+    summary:
+      type: string
+      minLength: 1
+      description: Short factual summary of prepared QA Lead test context output.
+      example: Prepared integration test cases for backend agent action implementation.
+    integrationTestCases:
+      type: array
+      description: Structured integration test cases intended for downstream IT Test lane implementation.
+      items:
+        $ref: './qa-lead-integration-test-case-dto.yml#/QaLeadIntegrationTestCaseDTO'
+    unitTestNotes:
+      type: array
+      description: Optional concise attention notes for downstream Unit Test lane.
+      items:
+        $ref: './qa-lead-unit-test-note-dto.yml#/QaLeadUnitTestNoteDTO'

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-qa-lead-lane-response-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-qa-lead-lane-response-dto.yml
@@ -1,0 +1,22 @@
+CompleteQaLeadLaneResponseDTO:
+  type: object
+  additionalProperties: false
+  required:
+    - ticketId
+    - laneId
+    - status
+  properties:
+    ticketId:
+      type: string
+      format: uuid
+      description: Ticket identifier that was used to complete the QA Lead lane.
+      example: 8f6f38ca-2f27-4c6a-a7f4-d6a1d7473f7e
+    laneId:
+      type: string
+      format: uuid
+      description: QA Lead lane identifier that was completed.
+      example: 3c7ea31b-8660-4f89-a124-72be9d1b58f5
+    status:
+      type: string
+      description: Resulting lane status after successful QA Lead completion.
+      example: DONE

--- a/apis/fgaisox/rest/schemas/v1/forgeai/qa-lead-data-check-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/qa-lead-data-check-dto.yml
@@ -1,0 +1,17 @@
+QaLeadDataCheckDTO:
+  type: object
+  additionalProperties: false
+  required:
+    - target
+    - expectation
+  properties:
+    target:
+      type: string
+      minLength: 1
+      description: Persistence object that must be verified (table, collection, column, projection, or persisted object).
+      example: agent_actions
+    expectation:
+      type: string
+      minLength: 1
+      description: Expected persisted data state after the tested flow execution.
+      example: New row exists for the requested agent action

--- a/apis/fgaisox/rest/schemas/v1/forgeai/qa-lead-integration-flow-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/qa-lead-integration-flow-dto.yml
@@ -1,0 +1,31 @@
+QaLeadIntegrationFlowDTO:
+  type: object
+  additionalProperties: false
+  required:
+    - name
+  properties:
+    name:
+      type: string
+      minLength: 1
+      description: Human-readable integration flow name covered by the integration test case.
+      example: Create agent action
+    operationId:
+      type: string
+      nullable: true
+      description: OpenAPI operationId for API-first flows when available in the contract.
+      example: createAgentAction
+    method:
+      type: string
+      description: HTTP method for REST/API flow; should be provided for REST test cases.
+      enum:
+        - GET
+        - POST
+        - PUT
+        - PATCH
+        - DELETE
+      example: POST
+    path:
+      type: string
+      description: REST path covered by this test case flow; should be provided for REST test cases and start with '/'.
+      pattern: '^/'
+      example: /api/v1/agent-actions

--- a/apis/fgaisox/rest/schemas/v1/forgeai/qa-lead-integration-test-case-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/qa-lead-integration-test-case-dto.yml
@@ -1,0 +1,52 @@
+QaLeadIntegrationTestCaseDTO:
+  type: object
+  additionalProperties: false
+  required:
+    - title
+    - flow
+    - given
+    - when
+    - then
+    - priority
+  properties:
+    title:
+      type: string
+      minLength: 1
+      description: Short action-oriented integration test case title.
+      example: Create agent action successfully
+    flow:
+      $ref: './qa-lead-integration-flow-dto.yml#/QaLeadIntegrationFlowDTO'
+    given:
+      type: array
+      minItems: 1
+      description: Preconditions required before running the integration test case.
+      items:
+        type: string
+        minLength: 1
+    when:
+      type: array
+      minItems: 1
+      description: Action performed by the integration test case.
+      items:
+        type: string
+        minLength: 1
+    then:
+      type: array
+      minItems: 1
+      description: Observable expected results that must be asserted.
+      items:
+        type: string
+        minLength: 1
+    dataChecks:
+      type: array
+      description: Optional persistence/data assertions relevant for this integration test case.
+      items:
+        $ref: './qa-lead-data-check-dto.yml#/QaLeadDataCheckDTO'
+    priority:
+      type: string
+      description: Integration test case importance for downstream IT Test lane planning.
+      enum:
+        - HIGH
+        - MEDIUM
+        - LOW
+      example: HIGH

--- a/apis/fgaisox/rest/schemas/v1/forgeai/qa-lead-unit-test-note-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/qa-lead-unit-test-note-dto.yml
@@ -1,0 +1,17 @@
+QaLeadUnitTestNoteDTO:
+  type: object
+  additionalProperties: false
+  required:
+    - target
+    - note
+  properties:
+    target:
+      type: string
+      minLength: 1
+      description: Specific area/class/use-case/behavior that Unit Test lane should pay attention to.
+      example: CreateAgentActionUseCase
+    note:
+      type: string
+      minLength: 1
+      description: Concise unit-test attention note without test code or full test-case steps.
+      example: Pay attention to unknown agent id and unsupported action type handling.


### PR DESCRIPTION
## Summary
- add POST /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/qa-lead/complete
- add strict QA Lead completion DTOs with detailed field descriptions
- register new path and schemas in fgaisox OpenAPI
- bump fgaisox API version to 0.0.9

## Contract scope
- accepted root fields: scope, summary, integrationTestCases, unitTestNotes
- response fields: ticketId, laneId, status
- ticketId/laneId are UUID-formatted strings in path params and response