### PR TITLE
[SITIONIX-9] - add Unit Test lane completion endpoint contract

### DIFF
--- a/apis/fgaisox/rest/metadata.yml
+++ b/apis/fgaisox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.9
+  version: 0.0.10
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Forge AI Service Sitionix
   description: API specification for Forge AI service
-  version: 0.0.9
+  version: 0.0.10
   contact:
     name: APP Sitionix
 servers:
@@ -23,6 +23,8 @@ paths:
     $ref: './paths/v1/forge-ai-complete-implement-be-lane.yml'
   /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/qa-lead/complete:
     $ref: './paths/v1/forge-ai-complete-qa-lead-lane.yml'
+  /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/test-unit/complete:
+    $ref: './paths/v1/forge-ai-complete-unit-test-lane.yml'
 components:
   securitySchemes:
     bearerAuth:
@@ -93,6 +95,12 @@ components:
       $ref: './schemas/v1/forgeai/qa-lead-unit-test-note-dto.yml#/QaLeadUnitTestNoteDTO'
     CompleteQaLeadLaneResponseDTO:
       $ref: './schemas/v1/forgeai/complete-qa-lead-lane-response-dto.yml#/CompleteQaLeadLaneResponseDTO'
+    CompleteUnitTestLaneRequestDTO:
+      $ref: './schemas/v1/forgeai/complete-unit-test-lane-request-dto.yml#/CompleteUnitTestLaneRequestDTO'
+    UnitTestSonarDTO:
+      $ref: './schemas/v1/forgeai/unit-test-sonar-dto.yml#/UnitTestSonarDTO'
+    CompleteUnitTestLaneResponseDTO:
+      $ref: './schemas/v1/forgeai/complete-unit-test-lane-response-dto.yml#/CompleteUnitTestLaneResponseDTO'
     AgentDTO:
       $ref: './schemas/shared/agent-dto.yml#/AgentDTO'
     ErrorDTO:

--- a/apis/fgaisox/rest/paths/v1/forge-ai-complete-unit-test-lane.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-complete-unit-test-lane.yml
@@ -1,0 +1,57 @@
+post:
+  tags:
+    - ForgeAI
+  summary: Complete Unit Test lane
+  operationId: completeUnitTestLane
+  parameters:
+    - name: ticketId
+      in: path
+      required: true
+      description: Forge AI ticket identifier in UUID format.
+      schema:
+        type: string
+        format: uuid
+    - name: laneId
+      in: path
+      required: true
+      description: Unit Test lane identifier in UUID format.
+      schema:
+        type: string
+        format: uuid
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/CompleteUnitTestLaneRequestDTO'
+  responses:
+    '200':
+      description: Unit Test lane completion accepted.
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/CompleteUnitTestLaneResponseDTO'
+    '400':
+      description: Validation failed (VALIDATION_FAILED).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      description: Ticket or lane not found (TICKET_NOT_FOUND, LANE_NOT_FOUND).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '409':
+      description: Invalid lane state/agent/scope (INVALID_LANE_AGENT, INVALID_LANE_STATE, LANE_SCOPE_MISMATCH).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-unit-test-lane-request-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-unit-test-lane-request-dto.yml
@@ -1,0 +1,29 @@
+CompleteUnitTestLaneRequestDTO:
+  type: object
+  additionalProperties: false
+  required:
+    - scope
+    - summary
+    - affectedFiles
+    - sonar
+  properties:
+    scope:
+      type: string
+      minLength: 1
+      description: Assigned backend service scope where unit-test work was completed; must match Unit Test lane scope.
+      example: automationservice-sox
+    summary:
+      type: string
+      minLength: 1
+      description: Short factual summary of completed unit-test work.
+      example: Added unit coverage for affected backend files.
+    affectedFiles:
+      type: array
+      minItems: 1
+      description: Repository-relative implementation source files covered or checked by Unit Test lane.
+      items:
+        type: string
+        minLength: 1
+        example: automationservice-sox/src/main/java/com/sitionix/atmssox/application/agent/CreateAgentActionUseCase.java
+    sonar:
+      $ref: './unit-test-sonar-dto.yml#/UnitTestSonarDTO'

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-unit-test-lane-response-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-unit-test-lane-response-dto.yml
@@ -1,0 +1,22 @@
+CompleteUnitTestLaneResponseDTO:
+  type: object
+  additionalProperties: false
+  required:
+    - ticketId
+    - laneId
+    - status
+  properties:
+    ticketId:
+      type: string
+      format: uuid
+      description: Ticket identifier that was used to complete the Unit Test lane.
+      example: 8f6f38ca-2f27-4c6a-a7f4-d6a1d7473f7e
+    laneId:
+      type: string
+      format: uuid
+      description: Unit Test lane identifier that was completed.
+      example: 3c7ea31b-8660-4f89-a124-72be9d1b58f5
+    status:
+      type: string
+      description: Resulting lane status after successful Unit Test completion.
+      example: DONE

--- a/apis/fgaisox/rest/schemas/v1/forgeai/unit-test-sonar-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/unit-test-sonar-dto.yml
@@ -1,0 +1,19 @@
+UnitTestSonarDTO:
+  type: object
+  additionalProperties: false
+  required:
+    - coveragePercent
+    - issues
+  properties:
+    coveragePercent:
+      type: number
+      format: double
+      minimum: 90.0
+      maximum: 100.0
+      description: Aggregated Sonar coverage percentage after unit-test work; must be between 90.0 and 100.0 inclusive.
+      example: 94.2
+    issues:
+      type: integer
+      minimum: 0
+      description: Aggregated number of Sonar issues for this Unit Test lane result.
+      example: 0


### PR DESCRIPTION
## Summary
- add POST /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/test-unit/complete
- add strict Unit Test completion request/response DTOs with clear field descriptions
- add aggregated sonar DTO with validation: coveragePercent 90.0..100.0 and issues >= 0
- register new path/schemas in fgaisox OpenAPI
- bump fgaisox API version to 0.0.10

## Contract scope
- accepted root fields: scope, summary, affectedFiles, sonar
- response fields: ticketId, laneId, status
- ticketId/laneId are UUID-formatted strings in path params and response