### PR TITLE
[SITIONIX-10] - extend QA Lead routing and add IT/UI test completion contracts

### DIFF
--- a/apis/fgaisox/rest/metadata.yml
+++ b/apis/fgaisox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.10
+  version: 0.0.11
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -89,8 +89,8 @@ components:
       $ref: './schemas/v1/forgeai/complete-implement-be-lane-response.yml#/CompleteImplementBeLaneResponseDTO'
     CompleteQaLeadLaneRequestDTO:
       $ref: './schemas/v1/forgeai/complete-qa-lead-lane-request-dto.yml#/CompleteQaLeadLaneRequestDTO'
-    QaLeadTestRoutingDTO:
-      $ref: './schemas/v1/forgeai/qa-lead-test-routing-dto.yml#/QaLeadTestRoutingDTO'
+    QaLeadTestLaneRequirementsDTO:
+      $ref: './schemas/v1/forgeai/qa-lead-test-lane-requirements-dto.yml#/QaLeadTestLaneRequirementsDTO'
     QaLeadIntegrationTestCaseDTO:
       $ref: './schemas/v1/forgeai/qa-lead-integration-test-case-dto.yml#/QaLeadIntegrationTestCaseDTO'
     QaLeadIntegrationFlowDTO:

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Forge AI Service Sitionix
   description: API specification for Forge AI service
-  version: 0.0.10
+  version: 0.0.11
   contact:
     name: APP Sitionix
 servers:
@@ -25,6 +25,10 @@ paths:
     $ref: './paths/v1/forge-ai-complete-qa-lead-lane.yml'
   /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/test-unit/complete:
     $ref: './paths/v1/forge-ai-complete-unit-test-lane.yml'
+  /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/test-it/complete:
+    $ref: './paths/v1/forge-ai-complete-it-test-lane.yml'
+  /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/test-ui/complete:
+    $ref: './paths/v1/forge-ai-complete-ui-test-lane.yml'
 components:
   securitySchemes:
     bearerAuth:
@@ -85,6 +89,8 @@ components:
       $ref: './schemas/v1/forgeai/complete-implement-be-lane-response.yml#/CompleteImplementBeLaneResponseDTO'
     CompleteQaLeadLaneRequestDTO:
       $ref: './schemas/v1/forgeai/complete-qa-lead-lane-request-dto.yml#/CompleteQaLeadLaneRequestDTO'
+    QaLeadTestRoutingDTO:
+      $ref: './schemas/v1/forgeai/qa-lead-test-routing-dto.yml#/QaLeadTestRoutingDTO'
     QaLeadIntegrationTestCaseDTO:
       $ref: './schemas/v1/forgeai/qa-lead-integration-test-case-dto.yml#/QaLeadIntegrationTestCaseDTO'
     QaLeadIntegrationFlowDTO:
@@ -101,6 +107,14 @@ components:
       $ref: './schemas/v1/forgeai/unit-test-sonar-dto.yml#/UnitTestSonarDTO'
     CompleteUnitTestLaneResponseDTO:
       $ref: './schemas/v1/forgeai/complete-unit-test-lane-response-dto.yml#/CompleteUnitTestLaneResponseDTO'
+    CompleteItTestLaneRequestDTO:
+      $ref: './schemas/v1/forgeai/complete-it-test-lane-request-dto.yml#/CompleteItTestLaneRequestDTO'
+    CompleteItTestLaneResponseDTO:
+      $ref: './schemas/v1/forgeai/complete-it-test-lane-response-dto.yml#/CompleteItTestLaneResponseDTO'
+    CompleteUiTestLaneRequestDTO:
+      $ref: './schemas/v1/forgeai/complete-ui-test-lane-request-dto.yml#/CompleteUiTestLaneRequestDTO'
+    CompleteUiTestLaneResponseDTO:
+      $ref: './schemas/v1/forgeai/complete-ui-test-lane-response-dto.yml#/CompleteUiTestLaneResponseDTO'
     AgentDTO:
       $ref: './schemas/shared/agent-dto.yml#/AgentDTO'
     ErrorDTO:

--- a/apis/fgaisox/rest/paths/v1/forge-ai-complete-it-test-lane.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-complete-it-test-lane.yml
@@ -1,0 +1,57 @@
+post:
+  tags:
+    - ForgeAI
+  summary: Complete IT Test lane
+  operationId: completeItTestLane
+  parameters:
+    - name: ticketId
+      in: path
+      required: true
+      description: Forge AI ticket identifier in UUID format.
+      schema:
+        type: string
+        format: uuid
+    - name: laneId
+      in: path
+      required: true
+      description: IT Test lane identifier in UUID format.
+      schema:
+        type: string
+        format: uuid
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/CompleteItTestLaneRequestDTO'
+  responses:
+    '200':
+      description: IT Test lane completion accepted.
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/CompleteItTestLaneResponseDTO'
+    '400':
+      description: Validation failed (VALIDATION_FAILED).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      description: Ticket or lane not found (TICKET_NOT_FOUND, LANE_NOT_FOUND).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '409':
+      description: Invalid lane state/agent/scope (INVALID_LANE_AGENT, INVALID_LANE_STATE, LANE_SCOPE_MISMATCH).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/fgaisox/rest/paths/v1/forge-ai-complete-ui-test-lane.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-complete-ui-test-lane.yml
@@ -1,0 +1,57 @@
+post:
+  tags:
+    - ForgeAI
+  summary: Complete UI Test lane
+  operationId: completeUiTestLane
+  parameters:
+    - name: ticketId
+      in: path
+      required: true
+      description: Forge AI ticket identifier in UUID format.
+      schema:
+        type: string
+        format: uuid
+    - name: laneId
+      in: path
+      required: true
+      description: UI Test lane identifier in UUID format.
+      schema:
+        type: string
+        format: uuid
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/CompleteUiTestLaneRequestDTO'
+  responses:
+    '200':
+      description: UI Test lane completion accepted.
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/CompleteUiTestLaneResponseDTO'
+    '400':
+      description: Validation failed (VALIDATION_FAILED).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      description: Ticket or lane not found (TICKET_NOT_FOUND, LANE_NOT_FOUND).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '409':
+      description: Invalid lane state/agent/scope (INVALID_LANE_AGENT, INVALID_LANE_STATE, LANE_SCOPE_MISMATCH).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-it-test-lane-request-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-it-test-lane-request-dto.yml
@@ -1,0 +1,27 @@
+CompleteItTestLaneRequestDTO:
+  type: object
+  additionalProperties: false
+  required:
+    - scope
+    - summary
+    - coveredCases
+  properties:
+    scope:
+      type: string
+      minLength: 1
+      description: Assigned backend service scope where integration-test work was completed.
+      example: automationservice-sox
+    summary:
+      type: string
+      minLength: 1
+      description: Short factual summary of completed integration-test work.
+      example: Completed integration tests for backend flow.
+    coveredCases:
+      type: array
+      minItems: 1
+      description: Names of integration test cases covered by IT Test lane completion.
+      items:
+        type: string
+        minLength: 1
+        description: Covered integration test case name.
+        example: Create agent action successfully

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-it-test-lane-response-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-it-test-lane-response-dto.yml
@@ -1,0 +1,22 @@
+CompleteItTestLaneResponseDTO:
+  type: object
+  additionalProperties: false
+  required:
+    - ticketId
+    - laneId
+    - status
+  properties:
+    ticketId:
+      type: string
+      format: uuid
+      description: Ticket identifier used to complete the IT Test lane.
+      example: 8f6f38ca-2f27-4c6a-a7f4-d6a1d7473f7e
+    laneId:
+      type: string
+      format: uuid
+      description: IT Test lane identifier that was completed.
+      example: 3c7ea31b-8660-4f89-a124-72be9d1b58f5
+    status:
+      type: string
+      description: Resulting lane status after successful IT Test completion.
+      example: DONE

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-qa-lead-lane-request-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-qa-lead-lane-request-dto.yml
@@ -4,6 +4,7 @@ CompleteQaLeadLaneRequestDTO:
   required:
     - scope
     - summary
+    - testRouting
     - integrationTestCases
     - unitTestNotes
   properties:
@@ -17,6 +18,8 @@ CompleteQaLeadLaneRequestDTO:
       minLength: 1
       description: Short factual summary of prepared QA Lead test context output.
       example: Prepared integration test cases for backend agent action implementation.
+    testRouting:
+      $ref: './qa-lead-test-routing-dto.yml#/QaLeadTestRoutingDTO'
     integrationTestCases:
       type: array
       description: Structured integration test cases intended for downstream IT Test lane implementation.

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-qa-lead-lane-request-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-qa-lead-lane-request-dto.yml
@@ -4,9 +4,10 @@ CompleteQaLeadLaneRequestDTO:
   required:
     - scope
     - summary
-    - testRouting
+    - testLaneRequirements
     - integrationTestCases
     - unitTestNotes
+    - uiTestNotes
   properties:
     scope:
       type: string
@@ -18,8 +19,8 @@ CompleteQaLeadLaneRequestDTO:
       minLength: 1
       description: Short factual summary of prepared QA Lead test context output.
       example: Prepared integration test cases for backend agent action implementation.
-    testRouting:
-      $ref: './qa-lead-test-routing-dto.yml#/QaLeadTestRoutingDTO'
+    testLaneRequirements:
+      $ref: './qa-lead-test-lane-requirements-dto.yml#/QaLeadTestLaneRequirementsDTO'
     integrationTestCases:
       type: array
       description: Structured integration test cases intended for downstream IT Test lane implementation.
@@ -28,5 +29,10 @@ CompleteQaLeadLaneRequestDTO:
     unitTestNotes:
       type: array
       description: Optional concise attention notes for downstream Unit Test lane.
+      items:
+        $ref: './qa-lead-unit-test-note-dto.yml#/QaLeadUnitTestNoteDTO'
+    uiTestNotes:
+      type: array
+      description: Optional concise attention notes for downstream UI Test lane; same note structure as unitTestNotes.
       items:
         $ref: './qa-lead-unit-test-note-dto.yml#/QaLeadUnitTestNoteDTO'

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-ui-test-lane-request-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-ui-test-lane-request-dto.yml
@@ -1,0 +1,27 @@
+CompleteUiTestLaneRequestDTO:
+  type: object
+  additionalProperties: false
+  required:
+    - scope
+    - summary
+    - coveredCases
+  properties:
+    scope:
+      type: string
+      minLength: 1
+      description: Assigned frontend scope where UI-test work was completed.
+      example: sitionix-spa
+    summary:
+      type: string
+      minLength: 1
+      description: Short factual summary of completed UI-test work.
+      example: Completed UI tests for frontend flow.
+    coveredCases:
+      type: array
+      minItems: 1
+      description: Names of UI test cases covered by UI Test lane completion.
+      items:
+        type: string
+        minLength: 1
+        description: Covered UI test case name.
+        example: User can create agent action from UI

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-ui-test-lane-response-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-ui-test-lane-response-dto.yml
@@ -1,0 +1,22 @@
+CompleteUiTestLaneResponseDTO:
+  type: object
+  additionalProperties: false
+  required:
+    - ticketId
+    - laneId
+    - status
+  properties:
+    ticketId:
+      type: string
+      format: uuid
+      description: Ticket identifier used to complete the UI Test lane.
+      example: 8f6f38ca-2f27-4c6a-a7f4-d6a1d7473f7e
+    laneId:
+      type: string
+      format: uuid
+      description: UI Test lane identifier that was completed.
+      example: 3c7ea31b-8660-4f89-a124-72be9d1b58f5
+    status:
+      type: string
+      description: Resulting lane status after successful UI Test completion.
+      example: DONE

--- a/apis/fgaisox/rest/schemas/v1/forgeai/qa-lead-test-lane-requirements-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/qa-lead-test-lane-requirements-dto.yml
@@ -1,4 +1,4 @@
-QaLeadTestRoutingDTO:
+QaLeadTestLaneRequirementsDTO:
   type: object
   additionalProperties: false
   required:

--- a/apis/fgaisox/rest/schemas/v1/forgeai/qa-lead-test-routing-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/qa-lead-test-routing-dto.yml
@@ -1,0 +1,20 @@
+QaLeadTestRoutingDTO:
+  type: object
+  additionalProperties: false
+  required:
+    - unitTestRequired
+    - integrationTestRequired
+    - uiTestRequired
+  properties:
+    unitTestRequired:
+      type: boolean
+      description: Whether Unit Test lane is required for the assigned scope after QA Lead analysis.
+      example: true
+    integrationTestRequired:
+      type: boolean
+      description: Whether Integration Test lane is required for the assigned scope after QA Lead analysis.
+      example: true
+    uiTestRequired:
+      type: boolean
+      description: Whether UI Test lane is required for the assigned scope after QA Lead analysis.
+      example: false


### PR DESCRIPTION
## Summary
- extend QA Lead completion contract with explicit downstream test routing flags
- add IT Test completion endpoint: POST /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/test-it/complete
- add UI Test completion endpoint: POST /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/test-ui/complete
- add strict request/response DTOs with field descriptions for Codex consumption
- register new paths/schemas in fgaisox OpenAPI
- bump fgaisox API version to 0.0.11

## Contract details
- QA Lead routing: unitTestRequired, integrationTestRequired, uiTestRequired
- IT/UI completion payload: scope, summary, coveredCases
- callback response payload: ticketId, laneId, status