### PR TITLE
[SITIONIX-11] - add implement fe completion contract

### DIFF
--- a/apis/fgaisox/rest/metadata.yml
+++ b/apis/fgaisox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.11
+  version: 0.0.12
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Forge AI Service Sitionix
   description: API specification for Forge AI service
-  version: 0.0.11
+  version: 0.0.12
   contact:
     name: APP Sitionix
 servers:
@@ -29,6 +29,8 @@ paths:
     $ref: './paths/v1/forge-ai-complete-it-test-lane.yml'
   /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/test-ui/complete:
     $ref: './paths/v1/forge-ai-complete-ui-test-lane.yml'
+  /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/implement-fe/complete:
+    $ref: './paths/v1/forge-ai-complete-implement-fe-lane.yml'
 components:
   securitySchemes:
     bearerAuth:
@@ -115,6 +117,14 @@ components:
       $ref: './schemas/v1/forgeai/complete-ui-test-lane-request-dto.yml#/CompleteUiTestLaneRequestDTO'
     CompleteUiTestLaneResponseDTO:
       $ref: './schemas/v1/forgeai/complete-ui-test-lane-response-dto.yml#/CompleteUiTestLaneResponseDTO'
+    CompleteImplementFeLaneRequestDTO:
+      $ref: './schemas/v1/forgeai/complete-implement-fe-lane-request-dto.yml#/CompleteImplementFeLaneRequestDTO'
+    ImplementFeChangedFileDTO:
+      $ref: './schemas/v1/forgeai/implement-fe-changed-file-dto.yml#/ImplementFeChangedFileDTO'
+    ImplementFeAffectedSurfaceDTO:
+      $ref: './schemas/v1/forgeai/implement-fe-affected-surface-dto.yml#/ImplementFeAffectedSurfaceDTO'
+    CompleteImplementFeLaneResponseDTO:
+      $ref: './schemas/v1/forgeai/complete-implement-fe-lane-response-dto.yml#/CompleteImplementFeLaneResponseDTO'
     AgentDTO:
       $ref: './schemas/shared/agent-dto.yml#/AgentDTO'
     ErrorDTO:

--- a/apis/fgaisox/rest/paths/v1/forge-ai-complete-implement-fe-lane.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-complete-implement-fe-lane.yml
@@ -1,0 +1,57 @@
+post:
+  tags:
+    - ForgeAI
+  summary: Complete frontend implementation lane
+  operationId: completeImplementFeLane
+  parameters:
+    - name: ticketId
+      in: path
+      required: true
+      description: Forge AI ticket identifier in UUID format.
+      schema:
+        type: string
+        format: uuid
+    - name: laneId
+      in: path
+      required: true
+      description: Frontend implementer lane identifier in UUID format.
+      schema:
+        type: string
+        format: uuid
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/CompleteImplementFeLaneRequestDTO'
+  responses:
+    '200':
+      description: Frontend implementation lane completion accepted.
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/CompleteImplementFeLaneResponseDTO'
+    '400':
+      description: Validation failed (VALIDATION_FAILED).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      description: Ticket or lane not found (TICKET_NOT_FOUND, LANE_NOT_FOUND).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '409':
+      description: Invalid lane state/agent/scope (INVALID_LANE_AGENT, INVALID_LANE_STATE, LANE_SCOPE_MISMATCH).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-implement-fe-lane-request-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-implement-fe-lane-request-dto.yml
@@ -1,0 +1,39 @@
+CompleteImplementFeLaneRequestDTO:
+  type: object
+  additionalProperties: false
+  required:
+    - scope
+    - summary
+    - changedFiles
+    - affectedSurfaces
+    - uiBehavior
+  properties:
+    scope:
+      type: string
+      minLength: 1
+      description: Assigned frontend scope where implementation was completed and that must match the lane scope.
+      example: sitionix-spa
+    summary:
+      type: string
+      minLength: 1
+      description: Short factual summary of the completed frontend implementation.
+      example: Implemented frontend changes for agent action creation flow.
+    changedFiles:
+      type: array
+      minItems: 1
+      description: Repository-relative frontend source files changed by the FE implementer.
+      items:
+        $ref: './implement-fe-changed-file-dto.yml#/ImplementFeChangedFileDTO'
+    affectedSurfaces:
+      type: array
+      description: Frontend surfaces affected by the implementation, such as pages, components, routes, or styles.
+      items:
+        $ref: './implement-fe-affected-surface-dto.yml#/ImplementFeAffectedSurfaceDTO'
+    uiBehavior:
+      type: array
+      description: User-visible behavior changes implemented by the frontend lane.
+      items:
+        type: string
+        minLength: 1
+        description: Single implemented UI behavior item.
+        example: User can open action creation UI from agent details page.

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-implement-fe-lane-response-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-implement-fe-lane-response-dto.yml
@@ -1,0 +1,22 @@
+CompleteImplementFeLaneResponseDTO:
+  type: object
+  additionalProperties: false
+  required:
+    - ticketId
+    - laneId
+    - status
+  properties:
+    ticketId:
+      type: string
+      format: uuid
+      description: Ticket identifier used to complete the frontend implementation lane.
+      example: 8f6f38ca-2f27-4c6a-a7f4-d6a1d7473f7e
+    laneId:
+      type: string
+      format: uuid
+      description: Frontend implementer lane identifier that was completed.
+      example: 3c7ea31b-8660-4f89-a124-72be9d1b58f5
+    status:
+      type: string
+      description: Resulting lane status after successful frontend implementation completion.
+      example: DONE

--- a/apis/fgaisox/rest/schemas/v1/forgeai/implement-fe-affected-surface-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/implement-fe-affected-surface-dto.yml
@@ -1,0 +1,31 @@
+ImplementFeAffectedSurfaceDTO:
+  type: object
+  additionalProperties: false
+  required:
+    - type
+    - name
+    - summary
+  properties:
+    type:
+      type: string
+      description: Frontend surface category affected by the implementation.
+      enum:
+        - ROUTE
+        - PAGE
+        - COMPONENT
+        - HOOK
+        - CLIENT
+        - STATE
+        - STYLE
+        - OTHER
+      example: PAGE
+    name:
+      type: string
+      minLength: 1
+      description: Human-readable name of the affected frontend surface.
+      example: Agent details
+    summary:
+      type: string
+      minLength: 1
+      description: Short explanation of how this frontend surface was affected.
+      example: Added user entry point for creating an agent action.

--- a/apis/fgaisox/rest/schemas/v1/forgeai/implement-fe-changed-file-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/implement-fe-changed-file-dto.yml
@@ -1,0 +1,17 @@
+ImplementFeChangedFileDTO:
+  type: object
+  additionalProperties: false
+  required:
+    - path
+    - reason
+  properties:
+    path:
+      type: string
+      minLength: 1
+      description: Repository-relative path to a changed frontend source file within the assigned frontend scope.
+      example: apps/workspace/src/features/agents/pages/AgentDetailsPage.tsx
+    reason:
+      type: string
+      minLength: 1
+      description: Short explanation of why this frontend file was changed.
+      example: Added action creation entry point on agent details page.


### PR DESCRIPTION
## Summary
- add POST /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/implement-fe/complete
- add strict FE implementation completion request/response DTOs
- add frontend changed file and affected surface DTOs with descriptions
- register new path and schemas in fgaisox OpenAPI
- bump fgaisox API version to 0.0.12

## Contract details
- request fields: scope, summary, changedFiles, affectedSurfaces, uiBehavior
- response fields: ticketId, laneId, status
- ticketId/laneId are UUID-formatted strings in path params and response