### PR TITLE
[SITIONIX-12] - align sonar fields for UI test and implementation lanes

### DIFF
--- a/apis/fgaisox/rest/metadata.yml
+++ b/apis/fgaisox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.12
+  version: 0.0.13
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Forge AI Service Sitionix
   description: API specification for Forge AI service
-  version: 0.0.12
+  version: 0.0.13
   contact:
     name: APP Sitionix
 servers:
@@ -107,6 +107,8 @@ components:
       $ref: './schemas/v1/forgeai/complete-unit-test-lane-request-dto.yml#/CompleteUnitTestLaneRequestDTO'
     UnitTestSonarDTO:
       $ref: './schemas/v1/forgeai/unit-test-sonar-dto.yml#/UnitTestSonarDTO'
+    ImplementationSonarDTO:
+      $ref: './schemas/v1/forgeai/implementation-sonar-dto.yml#/ImplementationSonarDTO'
     CompleteUnitTestLaneResponseDTO:
       $ref: './schemas/v1/forgeai/complete-unit-test-lane-response-dto.yml#/CompleteUnitTestLaneResponseDTO'
     CompleteItTestLaneRequestDTO:

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-implement-be-lane-request.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-implement-be-lane-request.yml
@@ -7,6 +7,7 @@ CompleteImplementBeLaneRequestDTO:
     - changedFiles
     - integrationFlows
     - persistenceChanges
+    - sonar
   properties:
     scope:
       type: string
@@ -34,3 +35,5 @@ CompleteImplementBeLaneRequestDTO:
       description: Implemented persistence/data-model changes for downstream Integration Test lane input.
       items:
         $ref: './implement-be-persistence-change.yml#/ImplementBePersistenceChangeDTO'
+    sonar:
+      $ref: './implementation-sonar-dto.yml#/ImplementationSonarDTO'

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-implement-fe-lane-request-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-implement-fe-lane-request-dto.yml
@@ -7,6 +7,7 @@ CompleteImplementFeLaneRequestDTO:
     - changedFiles
     - affectedSurfaces
     - uiBehavior
+    - sonar
   properties:
     scope:
       type: string
@@ -37,3 +38,5 @@ CompleteImplementFeLaneRequestDTO:
         minLength: 1
         description: Single implemented UI behavior item.
         example: User can open action creation UI from agent details page.
+    sonar:
+      $ref: './implementation-sonar-dto.yml#/ImplementationSonarDTO'

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-ui-test-lane-request-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-ui-test-lane-request-dto.yml
@@ -5,6 +5,7 @@ CompleteUiTestLaneRequestDTO:
     - scope
     - summary
     - coveredCases
+    - sonar
   properties:
     scope:
       type: string
@@ -25,3 +26,5 @@ CompleteUiTestLaneRequestDTO:
         minLength: 1
         description: Covered UI test case name.
         example: User can create agent action from UI
+    sonar:
+      $ref: './unit-test-sonar-dto.yml#/UnitTestSonarDTO'

--- a/apis/fgaisox/rest/schemas/v1/forgeai/implementation-sonar-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/implementation-sonar-dto.yml
@@ -1,0 +1,11 @@
+ImplementationSonarDTO:
+  type: object
+  additionalProperties: false
+  required:
+    - issues
+  properties:
+    issues:
+      type: integer
+      minimum: 0
+      description: Aggregated Sonar issues count for implementation lane completion.
+      example: 7


### PR DESCRIPTION
## Summary
- add  to UI test completion request using the same structure as unit test ()
- add implementation-level  object for backend/frontend implementation completions
- introduce  with aggregated  field
- wire new schema in fgaisox OpenAPI components
- bump fgaisox API version to 0.0.13

## Contract impact
-  now requires 
-  now requires 
-  now requires 