### PR TITLE
[SITIONIX-12] - bump fgaisox rest version to 0.0.14

### DIFF
--- a/apis/fgaisox/rest/metadata.yml
+++ b/apis/fgaisox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.13
+  version: 0.0.14
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Forge AI Service Sitionix
   description: API specification for Forge AI service
-  version: 0.0.13
+  version: 0.0.14
   contact:
     name: APP Sitionix
 servers:


### PR DESCRIPTION
## Summary
- bump apis/fgaisox/rest/metadata.yml version to 0.0.14
- bump apis/fgaisox/rest/openapi.yml info.version to 0.0.14

## Why
- ensure develop push publishes the next stable fgaisox API-first artifact version after PR #154