### PR TITLE
SITIONIX-15: remove start task length limit and bump fgaisox to 0.0.14

### DIFF
--- a/apis/fgaisox/rest/metadata.yml
+++ b/apis/fgaisox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.13
+  version: 0.0.14
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Forge AI Service Sitionix
   description: API specification for Forge AI service
-  version: 0.0.13
+  version: 0.0.14
   contact:
     name: APP Sitionix
 servers:

--- a/apis/fgaisox/rest/schemas/v1/forgeai/start-forge-request-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/start-forge-request-dto.yml
@@ -12,7 +12,6 @@ StartForgeRequestDTO:
     task:
       type: string
       minLength: 1
-      maxLength: 4000
     serviceIds:
       type: array
       minItems: 1


### PR DESCRIPTION
Summary:\n- removed maxLength 4000 from StartForgeRequestDTO.task\n- kept minLength 1\n- bumped FG AISOX REST API version from 0.0.13 to 0.0.14 in metadata/openapi\n\nWhy:\nLarge Forge AI tasks can exceed 4000 chars; start endpoint should not reject valid long tasks.\n\nChanged files:\n- apis/fgaisox/rest/schemas/v1/forgeai/start-forge-request-dto.yml\n- apis/fgaisox/rest/openapi.yml\n- apis/fgaisox/rest/metadata.yml