### PR TITLE
[SITIONIX-14] - add reviewer completion endpoint contract

### DIFF
--- a/apis/fgaisox/rest/metadata.yml
+++ b/apis/fgaisox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.14
+  version: 0.0.15
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/fgaisox/rest/metadata.yml
+++ b/apis/fgaisox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.13
+  version: 0.0.14
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/fgaisox/rest/metadata.yml
+++ b/apis/fgaisox/rest/metadata.yml
@@ -1,9 +1,5 @@
 api:
-<<<<<<< HEAD
   version: 0.0.16
-=======
-  version: 0.0.14
->>>>>>> origin/develop
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/fgaisox/rest/metadata.yml
+++ b/apis/fgaisox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.15
+  version: 0.0.16
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -2,11 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Forge AI Service Sitionix
   description: API specification for Forge AI service
-<<<<<<< HEAD
   version: 0.0.16
-=======
-  version: 0.0.14
->>>>>>> origin/develop
   contact:
     name: APP Sitionix
 servers:

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Forge AI Service Sitionix
   description: API specification for Forge AI service
-  version: 0.0.15
+  version: 0.0.16
   contact:
     name: APP Sitionix
 servers:
@@ -31,7 +31,7 @@ paths:
     $ref: './paths/v1/forge-ai-complete-ui-test-lane.yml'
   /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/implement-fe/complete:
     $ref: './paths/v1/forge-ai-complete-implement-fe-lane.yml'
-  /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/reviewer/complete:
+  /api/v1/forge-ai/tickets/{ticketId}/reviewer/complete:
     $ref: './paths/v1/forge-ai-complete-reviewer-lane.yml'
 components:
   securitySchemes:

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Forge AI Service Sitionix
   description: API specification for Forge AI service
-  version: 0.0.13
+  version: 0.0.14
   contact:
     name: APP Sitionix
 servers:

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Forge AI Service Sitionix
   description: API specification for Forge AI service
-  version: 0.0.14
+  version: 0.0.15
   contact:
     name: APP Sitionix
 servers:
@@ -31,6 +31,8 @@ paths:
     $ref: './paths/v1/forge-ai-complete-ui-test-lane.yml'
   /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/implement-fe/complete:
     $ref: './paths/v1/forge-ai-complete-implement-fe-lane.yml'
+  /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/reviewer/complete:
+    $ref: './paths/v1/forge-ai-complete-reviewer-lane.yml'
 components:
   securitySchemes:
     bearerAuth:
@@ -127,6 +129,8 @@ components:
       $ref: './schemas/v1/forgeai/implement-fe-affected-surface-dto.yml#/ImplementFeAffectedSurfaceDTO'
     CompleteImplementFeLaneResponseDTO:
       $ref: './schemas/v1/forgeai/complete-implement-fe-lane-response-dto.yml#/CompleteImplementFeLaneResponseDTO'
+    CompleteReviewerLaneResponseDTO:
+      $ref: './schemas/v1/forgeai/complete-reviewer-lane-response-dto.yml#/CompleteReviewerLaneResponseDTO'
     AgentDTO:
       $ref: './schemas/shared/agent-dto.yml#/AgentDTO'
     ErrorDTO:

--- a/apis/fgaisox/rest/paths/v1/forge-ai-complete-reviewer-lane.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-complete-reviewer-lane.yml
@@ -11,12 +11,6 @@ post:
       schema:
         type: string
         format: uuid
-    - name: laneId
-      in: path
-      required: true
-      description: Reviewer lane identifier from lane state.
-      schema:
-        type: string
   responses:
     '200':
       description: Reviewer lane completion accepted.

--- a/apis/fgaisox/rest/paths/v1/forge-ai-complete-reviewer-lane.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-complete-reviewer-lane.yml
@@ -1,0 +1,51 @@
+post:
+  tags:
+    - ForgeAI
+  summary: Complete reviewer lane
+  operationId: completeReviewerLane
+  parameters:
+    - name: ticketId
+      in: path
+      required: true
+      description: Forge AI ticket identifier in UUID format.
+      schema:
+        type: string
+        format: uuid
+    - name: laneId
+      in: path
+      required: true
+      description: Reviewer lane identifier in UUID format.
+      schema:
+        type: string
+        format: uuid
+  responses:
+    '200':
+      description: Reviewer lane completion accepted.
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/CompleteReviewerLaneResponseDTO'
+    '400':
+      description: Invalid request (for example invalid parameters or unexpected request body).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      description: Ticket or lane not found (TICKET_NOT_FOUND, LANE_NOT_FOUND).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '409':
+      description: Invalid lane state/type (INVALID_LANE_AGENT, INVALID_LANE_STATE).
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/ErrorDTO'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/fgaisox/rest/paths/v1/forge-ai-complete-reviewer-lane.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-complete-reviewer-lane.yml
@@ -14,10 +14,9 @@ post:
     - name: laneId
       in: path
       required: true
-      description: Reviewer lane identifier in UUID format.
+      description: Reviewer lane identifier from lane state.
       schema:
         type: string
-        format: uuid
   responses:
     '200':
       description: Reviewer lane completion accepted.

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-reviewer-lane-response-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-reviewer-lane-response-dto.yml
@@ -3,7 +3,6 @@ CompleteReviewerLaneResponseDTO:
   additionalProperties: false
   required:
     - ticketId
-    - laneId
     - status
   properties:
     ticketId:
@@ -11,10 +10,6 @@ CompleteReviewerLaneResponseDTO:
       format: uuid
       description: Ticket identifier that was used to complete the reviewer lane.
       example: 8f6f38ca-2f27-4c6a-a7f4-d6a1d7473f7e
-    laneId:
-      type: string
-      description: Reviewer lane identifier that was completed.
-      example: reviewer.automationservice-sox
     status:
       type: string
       description: Resulting lane status after successful reviewer completion.

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-reviewer-lane-response-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-reviewer-lane-response-dto.yml
@@ -13,9 +13,8 @@ CompleteReviewerLaneResponseDTO:
       example: 8f6f38ca-2f27-4c6a-a7f4-d6a1d7473f7e
     laneId:
       type: string
-      format: uuid
       description: Reviewer lane identifier that was completed.
-      example: 3c7ea31b-8660-4f89-a124-72be9d1b58f5
+      example: reviewer.automationservice-sox
     status:
       type: string
       description: Resulting lane status after successful reviewer completion.

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-reviewer-lane-response-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-reviewer-lane-response-dto.yml
@@ -1,0 +1,22 @@
+CompleteReviewerLaneResponseDTO:
+  type: object
+  additionalProperties: false
+  required:
+    - ticketId
+    - laneId
+    - status
+  properties:
+    ticketId:
+      type: string
+      format: uuid
+      description: Ticket identifier that was used to complete the reviewer lane.
+      example: 8f6f38ca-2f27-4c6a-a7f4-d6a1d7473f7e
+    laneId:
+      type: string
+      format: uuid
+      description: Reviewer lane identifier that was completed.
+      example: 3c7ea31b-8660-4f89-a124-72be9d1b58f5
+    status:
+      type: string
+      description: Resulting lane status after successful reviewer completion.
+      example: DONE

--- a/apis/fgaisox/rest/schemas/v1/forgeai/start-forge-request-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/start-forge-request-dto.yml
@@ -12,7 +12,6 @@ StartForgeRequestDTO:
     task:
       type: string
       minLength: 1
-      maxLength: 4000
     serviceIds:
       type: array
       minItems: 1


### PR DESCRIPTION
## Summary
- add POST /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/reviewer/complete
- keep endpoint bodyless (no request body)
- add standard completion response DTO with ticketId, laneId, status
- wire path and schema in fgaisox OpenAPI
- bump fgaisox API version to 0.0.15

## Notes
- reviewer completion is terminal and does not create downstream work
- error handling follows existing completion endpoint style (400/404/409/500)