### PR TITLE
[SITIONIX-138] - add conversation execution API contracts

### DIFF
--- a/apis/atmssox/rest/metadata.yml
+++ b/apis/atmssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.26
+  version: 0.0.27
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/atmssox/rest/openapi.yml
+++ b/apis/atmssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Automation Service Sitionix
   description: API specification for automation service
-  version: 0.0.26
+  version: 0.0.27
   contact:
     name: APP Sitionix
 servers:
@@ -55,6 +55,8 @@ paths:
     $ref: './paths/v1/agents-conversations.yml'
   /api/v1/conversations/{conversationId}:
     $ref: './paths/v1/agents-conversations-by-id.yml'
+  /api/v1/conversations/{conversationId}/executions:
+    $ref: './paths/v1/conversations-executions.yml'
 components:
   securitySchemes:
     bearerAuth:
@@ -93,6 +95,10 @@ components:
       $ref: './schemas/v1/agent/chat-agent-response-dto.yml#/ChatAgentResponseDTO'
     SubmitChatExecutionResponseDTO:
       $ref: './schemas/v1/agent/submit-chat-execution-response-dto.yml#/SubmitChatExecutionResponseDTO'
+    SubmitConversationExecutionRequestDTO:
+      $ref: './schemas/v1/agent/submit-conversation-execution-request-dto.yml#/SubmitConversationExecutionRequestDTO'
+    SubmitConversationExecutionResponseDTO:
+      $ref: './schemas/v1/agent/submit-conversation-execution-response-dto.yml#/SubmitConversationExecutionResponseDTO'
     ChatExecutionDTO:
       $ref: './schemas/v1/agent/chat-execution-dto.yml#/ChatExecutionDTO'
     ChatExecutionFailureDTO:

--- a/apis/atmssox/rest/paths/v1/conversations-executions.yml
+++ b/apis/atmssox/rest/paths/v1/conversations-executions.yml
@@ -1,0 +1,42 @@
+post:
+  tags:
+    - AgentConversation
+  operationId: submitConversationExecution
+  summary: Submit conversation execution
+  description: >
+    Persists a user message for an existing conversation and submits execution.
+    Execution may be terminal immediately when dispatch is skipped.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: conversationId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/SubmitConversationExecutionRequestDTO'
+  responses:
+    '200':
+      description: Conversation execution submitted
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/SubmitConversationExecutionResponseDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '409':
+      $ref: '../../openapi.yml#/components/responses/Conflict'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/atmssox/rest/schemas/v1/agent/execution-status-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/execution-status-dto.yml
@@ -7,3 +7,4 @@ ExecutionStatusDTO:
     - IN_PROGRESS
     - SUCCEEDED
     - FAILED
+    - DISPATCH_SKIPPED

--- a/apis/atmssox/rest/schemas/v1/agent/submit-conversation-execution-request-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/submit-conversation-execution-request-dto.yml
@@ -1,0 +1,13 @@
+SubmitConversationExecutionRequestDTO:
+  title: SubmitConversationExecutionRequestDTO
+  type: object
+  additionalProperties: false
+  required:
+    - message
+  properties:
+    message:
+      type: string
+      minLength: 1
+      pattern: ".*\\S.*"
+      description: User message to persist and execute.
+      example: Explain clean architecture in simple words.

--- a/apis/atmssox/rest/schemas/v1/agent/submit-conversation-execution-response-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/submit-conversation-execution-response-dto.yml
@@ -1,0 +1,24 @@
+SubmitConversationExecutionResponseDTO:
+  title: SubmitConversationExecutionResponseDTO
+  type: object
+  additionalProperties: false
+  required:
+    - conversationId
+    - inputMessageId
+    - executionStatus
+  properties:
+    conversationId:
+      type: string
+      format: uuid
+      description: Conversation identifier linked to this execution.
+    inputMessageId:
+      type: string
+      format: uuid
+      description: User message identifier persisted during submit transaction.
+    executionId:
+      type: string
+      format: uuid
+      nullable: true
+      description: Execution identifier when execution is created.
+    executionStatus:
+      $ref: './execution-status-dto.yml#/ExecutionStatusDTO'

--- a/apis/bffssox/rest/metadata.yml
+++ b/apis/bffssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.40
+  version: 0.0.41
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/bffssox/rest/openapi.yml
+++ b/apis/bffssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Backend for Frontend Sitionix
   description: API specification for the BFF authentication facade
-  version: 0.0.40
+  version: 0.0.41
   contact:
     name: APP Sitionix
 servers:
@@ -70,6 +70,8 @@ paths:
     $ref: './paths/v1/agents-conversations.yml'
   /api/v1/conversations/{conversationId}:
     $ref: './paths/v1/agents-conversations-by-id.yml'
+  /api/v1/conversations/{conversationId}/executions:
+    $ref: './paths/v1/conversations-executions.yml'
   /api/v1/auth/login:
     $ref: './paths/v1/auth-login.yml'
 components:
@@ -130,6 +132,10 @@ components:
       $ref: './schemas/v1/agent/chat-agent-response-dto.yml#/ChatAgentResponseDTO'
     SubmitChatExecutionResponseDTO:
       $ref: './schemas/v1/agent/submit-chat-execution-response-dto.yml#/SubmitChatExecutionResponseDTO'
+    SubmitConversationExecutionRequestDTO:
+      $ref: './schemas/v1/agent/submit-conversation-execution-request-dto.yml#/SubmitConversationExecutionRequestDTO'
+    SubmitConversationExecutionResponseDTO:
+      $ref: './schemas/v1/agent/submit-conversation-execution-response-dto.yml#/SubmitConversationExecutionResponseDTO'
     ChatExecutionDTO:
       $ref: './schemas/v1/agent/chat-execution-dto.yml#/ChatExecutionDTO'
     ChatExecutionFailureDTO:

--- a/apis/bffssox/rest/paths/v1/conversations-executions.yml
+++ b/apis/bffssox/rest/paths/v1/conversations-executions.yml
@@ -1,0 +1,42 @@
+post:
+  tags:
+    - AgentConversation
+  operationId: submitConversationExecution
+  summary: Submit conversation execution
+  description: >
+    Submits conversation message execution by existing conversation id.
+    Returns persisted message reference and execution status for SPA reconciliation.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: conversationId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../../openapi.yml#/components/schemas/SubmitConversationExecutionRequestDTO'
+  responses:
+    '200':
+      description: Conversation execution submitted
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/SubmitConversationExecutionResponseDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '401':
+      $ref: '../../openapi.yml#/components/responses/Unauthorized'
+    '403':
+      $ref: '../../openapi.yml#/components/responses/Forbidden'
+    '404':
+      $ref: '../../openapi.yml#/components/responses/NotFound'
+    '409':
+      $ref: '../../openapi.yml#/components/responses/Conflict'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/bffssox/rest/schemas/v1/agent/execution-status-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/execution-status-dto.yml
@@ -7,3 +7,4 @@ ExecutionStatusDTO:
     - IN_PROGRESS
     - SUCCEEDED
     - FAILED
+    - DISPATCH_SKIPPED

--- a/apis/bffssox/rest/schemas/v1/agent/submit-conversation-execution-request-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/submit-conversation-execution-request-dto.yml
@@ -1,0 +1,16 @@
+SubmitConversationExecutionRequestDTO:
+  title: SubmitConversationExecutionRequestDTO
+  type: object
+  additionalProperties: false
+  required:
+    - message
+  properties:
+    message:
+      type: string
+      minLength: 1
+      pattern: ".*\\S.*"
+      description: User message content to persist and execute.
+      example: Explain clean architecture in simple words.
+    clientRequestId:
+      type: string
+      description: Optional client correlation key used for idempotent retries.

--- a/apis/bffssox/rest/schemas/v1/agent/submit-conversation-execution-response-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/submit-conversation-execution-response-dto.yml
@@ -1,0 +1,24 @@
+SubmitConversationExecutionResponseDTO:
+  title: SubmitConversationExecutionResponseDTO
+  type: object
+  additionalProperties: false
+  required:
+    - conversationId
+    - inputMessageId
+    - executionStatus
+  properties:
+    conversationId:
+      type: string
+      format: uuid
+      description: Conversation identifier linked to this execution.
+    inputMessageId:
+      type: string
+      format: uuid
+      description: User message identifier persisted during submit transaction.
+    executionId:
+      type: string
+      format: uuid
+      nullable: true
+      description: Execution identifier when dispatch created execution.
+    executionStatus:
+      $ref: './execution-status-dto.yml#/ExecutionStatusDTO'


### PR DESCRIPTION
## Summary
- add POST /api/v1/conversations/{conversationId}/executions for atmssox and bffssox
- add request/response DTOs for conversation execution submit
- extend ExecutionStatusDTO with DISPATCH_SKIPPED
- bump REST versions (openapi + metadata) for changed surfaces