### PR TITLE
[SITIONIX-139] - align bffs conversation execution contract semantics

### DIFF
--- a/apis/atmssox/rest/metadata.yml
+++ b/apis/atmssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.27
+  version: 0.0.28
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/atmssox/rest/openapi.yml
+++ b/apis/atmssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Automation Service Sitionix
   description: API specification for automation service
-  version: 0.0.27
+  version: 0.0.28
   contact:
     name: APP Sitionix
 servers:

--- a/apis/atmssox/rest/paths/v1/conversations-executions.yml
+++ b/apis/atmssox/rest/paths/v1/conversations-executions.yml
@@ -4,8 +4,8 @@ post:
   operationId: submitConversationExecution
   summary: Submit conversation execution
   description: >
-    Persists a user message for an existing conversation and submits execution.
-    Execution may be terminal immediately when dispatch is skipped.
+    Persists a user message for an existing conversation.
+    Execution metadata is included only when runtime dispatch creates an execution.
   security:
     - bearerAuth: []
   parameters:

--- a/apis/atmssox/rest/schemas/v1/agent/agent-conversation-details-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/agent-conversation-details-dto.yml
@@ -10,7 +10,6 @@ AgentConversationDetailsDTO:
     - updatedAt
     - lastMessageAt
     - messages
-    - executions
   properties:
     id:
       type: string
@@ -42,8 +41,6 @@ AgentConversationDetailsDTO:
       description: Full ordered message history.
       items:
         $ref: './agent-conversation-message-dto.yml#/AgentConversationMessageDTO'
-    executions:
-      type: array
-      description: Ordered execution history for this conversation.
-      items:
-        $ref: './chat-execution-dto.yml#/ChatExecutionDTO'
+    execution:
+      $ref: './chat-execution-dto.yml#/ChatExecutionDTO'
+      description: Current execution context when runtime dispatch exists.

--- a/apis/atmssox/rest/schemas/v1/agent/execution-status-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/execution-status-dto.yml
@@ -7,4 +7,3 @@ ExecutionStatusDTO:
     - IN_PROGRESS
     - SUCCEEDED
     - FAILED
-    - DISPATCH_SKIPPED

--- a/apis/atmssox/rest/schemas/v1/agent/submit-conversation-execution-response-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/submit-conversation-execution-response-dto.yml
@@ -5,7 +5,7 @@ SubmitConversationExecutionResponseDTO:
   required:
     - conversationId
     - inputMessageId
-    - executionStatus
+    - runtimeDispatched
   properties:
     conversationId:
       type: string
@@ -15,10 +15,14 @@ SubmitConversationExecutionResponseDTO:
       type: string
       format: uuid
       description: User message identifier persisted during submit transaction.
+    runtimeDispatched:
+      type: boolean
+      description: Indicates whether runtime execution dispatch was created.
     executionId:
       type: string
       format: uuid
       nullable: true
-      description: Execution identifier when execution is created.
+      description: Execution identifier only when runtime dispatch created execution.
     executionStatus:
       $ref: './execution-status-dto.yml#/ExecutionStatusDTO'
+      description: Real execution lifecycle status only when execution exists.

--- a/apis/bffssox/rest/metadata.yml
+++ b/apis/bffssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.41
+  version: 0.0.42
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/bffssox/rest/openapi.yml
+++ b/apis/bffssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Backend for Frontend Sitionix
   description: API specification for the BFF authentication facade
-  version: 0.0.41
+  version: 0.0.42
   contact:
     name: APP Sitionix
 servers:

--- a/apis/bffssox/rest/paths/v1/conversations-executions.yml
+++ b/apis/bffssox/rest/paths/v1/conversations-executions.yml
@@ -4,8 +4,8 @@ post:
   operationId: submitConversationExecution
   summary: Submit conversation execution
   description: >
-    Submits conversation message execution by existing conversation id.
-    Returns persisted message reference and execution status for SPA reconciliation.
+    Persists a user message for an existing conversation.
+    Execution metadata is included only when runtime dispatch creates an execution.
   security:
     - bearerAuth: []
   parameters:

--- a/apis/bffssox/rest/schemas/v1/agent/agent-conversation-details-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agent-conversation-details-dto.yml
@@ -10,7 +10,6 @@ AgentConversationDetailsDTO:
     - updatedAt
     - lastMessageAt
     - messages
-    - executions
   properties:
     id:
       type: string
@@ -42,8 +41,6 @@ AgentConversationDetailsDTO:
       description: Full ordered message history.
       items:
         $ref: './agent-conversation-message-dto.yml#/AgentConversationMessageDTO'
-    executions:
-      type: array
-      description: Ordered execution history for this conversation.
-      items:
-        $ref: './chat-execution-dto.yml#/ChatExecutionDTO'
+    execution:
+      $ref: './chat-execution-dto.yml#/ChatExecutionDTO'
+      description: Current execution context when runtime dispatch exists.

--- a/apis/bffssox/rest/schemas/v1/agent/execution-status-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/execution-status-dto.yml
@@ -7,4 +7,3 @@ ExecutionStatusDTO:
     - IN_PROGRESS
     - SUCCEEDED
     - FAILED
-    - DISPATCH_SKIPPED

--- a/apis/bffssox/rest/schemas/v1/agent/submit-conversation-execution-response-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/submit-conversation-execution-response-dto.yml
@@ -5,7 +5,7 @@ SubmitConversationExecutionResponseDTO:
   required:
     - conversationId
     - inputMessageId
-    - executionStatus
+    - runtimeDispatched
   properties:
     conversationId:
       type: string
@@ -15,10 +15,14 @@ SubmitConversationExecutionResponseDTO:
       type: string
       format: uuid
       description: User message identifier persisted during submit transaction.
+    runtimeDispatched:
+      type: boolean
+      description: Indicates whether runtime execution dispatch was created.
     executionId:
       type: string
       format: uuid
       nullable: true
-      description: Execution identifier when dispatch created execution.
+      description: Execution identifier only when runtime dispatch created execution.
     executionStatus:
       $ref: './execution-status-dto.yml#/ExecutionStatusDTO'
+      description: Real execution lifecycle status only when execution exists.


### PR DESCRIPTION
## Summary
- remove synthetic DISPATCH_SKIPPED from bffs execution status enum
- make submit conversation execution metadata optional when runtime dispatch is not created
- expose runtimeDispatched flag as explicit branch signal
- align conversation details schema to optional single execution context
- bump bffssox REST version to 0.0.42

## Scope
- app-afesox / bffssox REST contract only