### PR TITLE
[SITIONIX-142] Add repo to API lane evidence contract

### DIFF
--- a/apis/atmssox/rest/metadata.yml
+++ b/apis/atmssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.28
+  version: 0.0.29
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/atmssox/rest/openapi.yml
+++ b/apis/atmssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Automation Service Sitionix
   description: API specification for automation service
-  version: 0.0.28
+  version: 0.0.29
   contact:
     name: APP Sitionix
 servers:
@@ -29,6 +29,10 @@ paths:
     $ref: './paths/v1/agent-projects-conversations.yml'
   /api/v1/agent-projects/{projectId}/conversations/{conversationId}:
     $ref: './paths/v1/agent-projects-conversations-by-id.yml'
+  /api/v1/agent-projects/{projectId}/flow:
+    $ref: './paths/v1/agent-projects-flow.yml'
+  /api/v1/agent-projects/{projectId}/flow/palette:
+    $ref: './paths/v1/agent-projects-flow-palette.yml'
   /api/v1/agents/{agentId}:
     $ref: './paths/v1/agents-by-id.yml'
   /api/v1/agents/{agentId}/activate:
@@ -81,6 +85,16 @@ components:
       $ref: './schemas/v1/agent/agent-project-dto.yml#/AgentProjectDTO'
     AgentProjectsPageResponseDTO:
       $ref: './schemas/v1/agent/agent-projects-page-response-dto.yml#/AgentProjectsPageResponseDTO'
+    AgentProjectFlowDTO:
+      $ref: './schemas/v1/agent/agent-project-flow-dto.yml#/AgentProjectFlowDTO'
+    AgentProjectFlowNodeDTO:
+      $ref: './schemas/v1/agent/agent-project-flow-node-dto.yml#/AgentProjectFlowNodeDTO'
+    AgentProjectFlowEdgeDTO:
+      $ref: './schemas/v1/agent/agent-project-flow-edge-dto.yml#/AgentProjectFlowEdgeDTO'
+    AgentProjectFlowPaletteItemDTO:
+      $ref: './schemas/v1/agent/agent-project-flow-palette-item-dto.yml#/AgentProjectFlowPaletteItemDTO'
+    AgentProjectFlowPaletteResponseDTO:
+      $ref: './schemas/v1/agent/agent-project-flow-palette-response-dto.yml#/AgentProjectFlowPaletteResponseDTO'
     ProjectAgentResponseDTO:
       $ref: './schemas/v1/agent/project-agent-response-dto.yml#/ProjectAgentResponseDTO'
     ProjectAgentsResponseDTO:

--- a/apis/atmssox/rest/paths/v1/agent-projects-flow-palette.yml
+++ b/apis/atmssox/rest/paths/v1/agent-projects-flow-palette.yml
@@ -1,0 +1,32 @@
+get:
+  tags:
+    - AgentProject
+  operationId: getAgentProjectFlowPalette
+  summary: Get agent project flow palette
+  description: >
+    Returns the available flow palette entries for the authenticated users agent project.
+    Returns 404 when project is missing, deleted, or not owned by the current user.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: projectId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    "200":
+      description: Agent project flow palette
+      content:
+        application/json:
+          schema:
+            $ref: "../../openapi.yml#/components/schemas/AgentProjectFlowPaletteResponseDTO"
+    "400":
+      $ref: "../../openapi.yml#/components/responses/BadRequest"
+    "401":
+      $ref: "../../openapi.yml#/components/responses/Unauthorized"
+    "404":
+      $ref: "../../openapi.yml#/components/responses/NotFound"
+    "500":
+      $ref: "../../openapi.yml#/components/responses/InternalServerError"

--- a/apis/atmssox/rest/paths/v1/agent-projects-flow.yml
+++ b/apis/atmssox/rest/paths/v1/agent-projects-flow.yml
@@ -1,0 +1,32 @@
+get:
+  tags:
+    - AgentProject
+  operationId: getAgentProjectFlow
+  summary: Get agent project flow graph
+  description: >
+    Returns the persisted flow graph for the authenticated users agent project.
+    Returns 404 when project is missing, deleted, or not owned by the current user.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: projectId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    "200":
+      description: Agent project flow graph
+      content:
+        application/json:
+          schema:
+            $ref: "../../openapi.yml#/components/schemas/AgentProjectFlowDTO"
+    "400":
+      $ref: "../../openapi.yml#/components/responses/BadRequest"
+    "401":
+      $ref: "../../openapi.yml#/components/responses/Unauthorized"
+    "404":
+      $ref: "../../openapi.yml#/components/responses/NotFound"
+    "500":
+      $ref: "../../openapi.yml#/components/responses/InternalServerError"

--- a/apis/atmssox/rest/schemas/v1/agent/agent-project-flow-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/agent-project-flow-dto.yml
@@ -1,0 +1,28 @@
+AgentProjectFlowDTO:
+  title: AgentProjectFlowDTO
+  type: object
+  additionalProperties: false
+  required:
+    - projectId
+    - nodes
+    - edges
+  properties:
+    projectId:
+      type: string
+      format: uuid
+      description: Agent project identifier.
+    flowId:
+      type: string
+      format: uuid
+      nullable: true
+      description: Flow identifier or null when no persisted flow exists.
+    nodes:
+      type: array
+      description: Persisted flow nodes.
+      items:
+        $ref: ./agent-project-flow-node-dto.yml#/AgentProjectFlowNodeDTO
+    edges:
+      type: array
+      description: Persisted flow edges.
+      items:
+        $ref: ./agent-project-flow-edge-dto.yml#/AgentProjectFlowEdgeDTO

--- a/apis/atmssox/rest/schemas/v1/agent/agent-project-flow-edge-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/agent-project-flow-edge-dto.yml
@@ -1,0 +1,25 @@
+AgentProjectFlowEdgeDTO:
+  title: AgentProjectFlowEdgeDTO
+  type: object
+  additionalProperties: false
+  required:
+    - source
+    - target
+    - edgeType
+    - configJson
+  properties:
+    source:
+      type: string
+      format: uuid
+      description: Source node reference identifier.
+    target:
+      type: string
+      format: uuid
+      description: Target node reference identifier.
+    edgeType:
+      type: string
+      description: Flow edge type.
+    configJson:
+      type: object
+      additionalProperties: true
+      description: Raw edge configuration payload.

--- a/apis/atmssox/rest/schemas/v1/agent/agent-project-flow-node-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/agent-project-flow-node-dto.yml
@@ -1,0 +1,33 @@
+AgentProjectFlowNodeDTO:
+  title: AgentProjectFlowNodeDTO
+  type: object
+  additionalProperties: false
+  required:
+    - nodeType
+    - referenceId
+    - label
+    - designStatus
+    - configJson
+  properties:
+    nodeType:
+      type: string
+      description: Flow node type.
+    referenceId:
+      type: string
+      format: uuid
+      description: Node reference identifier.
+    label:
+      type: string
+      description: Node label.
+    position:
+      type: object
+      nullable: true
+      additionalProperties: true
+      description: Optional node position payload.
+    designStatus:
+      type: string
+      description: Node design status.
+    configJson:
+      type: object
+      additionalProperties: true
+      description: Raw node configuration payload.

--- a/apis/atmssox/rest/schemas/v1/agent/agent-project-flow-palette-item-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/agent-project-flow-palette-item-dto.yml
@@ -1,0 +1,5 @@
+AgentProjectFlowPaletteItemDTO:
+  title: AgentProjectFlowPaletteItemDTO
+  type: object
+  additionalProperties: true
+  description: Flow palette item payload.

--- a/apis/atmssox/rest/schemas/v1/agent/agent-project-flow-palette-response-dto.yml
+++ b/apis/atmssox/rest/schemas/v1/agent/agent-project-flow-palette-response-dto.yml
@@ -1,0 +1,12 @@
+AgentProjectFlowPaletteResponseDTO:
+  title: AgentProjectFlowPaletteResponseDTO
+  type: object
+  additionalProperties: false
+  required:
+    - items
+  properties:
+    items:
+      type: array
+      description: Palette items containing one USER source and project-attached visible AGENT sources.
+      items:
+        $ref: ./agent-project-flow-palette-item-dto.yml#/AgentProjectFlowPaletteItemDTO

--- a/apis/bffssox/rest/metadata.yml
+++ b/apis/bffssox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.42
+  version: 0.0.43
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/bffssox/rest/openapi.yml
+++ b/apis/bffssox/rest/openapi.yml
@@ -122,6 +122,8 @@ components:
       $ref: './schemas/v1/agent/agent-project-dto.yml#/AgentProjectDTO'
     AgentProjectsPageResponseDTO:
       $ref: './schemas/v1/agent/agent-projects-page-response-dto.yml#/AgentProjectsPageResponseDTO'
+    AgentProjectFlowResponseDTO:
+      $ref: './schemas/v1/agent/agent-project-flow-response-dto.yml#/AgentProjectFlowResponseDTO'
     AgentProjectFlowDTO:
       $ref: './schemas/v1/agent/agent-project-flow-dto.yml#/AgentProjectFlowDTO'
     AgentProjectFlowNodeDTO:
@@ -130,6 +132,8 @@ components:
       $ref: './schemas/v1/agent/agent-project-flow-edge-dto.yml#/AgentProjectFlowEdgeDTO'
     AgentProjectFlowPaletteItemDTO:
       $ref: './schemas/v1/agent/agent-project-flow-palette-item-dto.yml#/AgentProjectFlowPaletteItemDTO'
+    AgentProjectFlowPaletteDTO:
+      $ref: './schemas/v1/agent/agent-project-flow-palette-dto.yml#/AgentProjectFlowPaletteDTO'
     AgentProjectFlowPaletteResponseDTO:
       $ref: './schemas/v1/agent/agent-project-flow-palette-response-dto.yml#/AgentProjectFlowPaletteResponseDTO'
     ProjectAgentResponseDTO:

--- a/apis/bffssox/rest/openapi.yml
+++ b/apis/bffssox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Backend for Frontend Sitionix
   description: API specification for the BFF authentication facade
-  version: 0.0.42
+  version: 0.0.43
   contact:
     name: APP Sitionix
 servers:
@@ -44,6 +44,10 @@ paths:
     $ref: './paths/v1/agent-projects-conversations.yml'
   /api/v1/agent-projects/{projectId}/conversations/{conversationId}:
     $ref: './paths/v1/agent-projects-conversations-by-id.yml'
+  /api/v1/agent-projects/{projectId}/flow:
+    $ref: './paths/v1/agent-projects-flow.yml'
+  /api/v1/agent-projects/{projectId}/flow/palette:
+    $ref: './paths/v1/agent-projects-flow-palette.yml'
   /api/v1/agents/{agentId}:
     $ref: './paths/v1/agents-by-id.yml'
   /api/v1/agents/{agentId}/activate:
@@ -118,6 +122,16 @@ components:
       $ref: './schemas/v1/agent/agent-project-dto.yml#/AgentProjectDTO'
     AgentProjectsPageResponseDTO:
       $ref: './schemas/v1/agent/agent-projects-page-response-dto.yml#/AgentProjectsPageResponseDTO'
+    AgentProjectFlowDTO:
+      $ref: './schemas/v1/agent/agent-project-flow-dto.yml#/AgentProjectFlowDTO'
+    AgentProjectFlowNodeDTO:
+      $ref: './schemas/v1/agent/agent-project-flow-node-dto.yml#/AgentProjectFlowNodeDTO'
+    AgentProjectFlowEdgeDTO:
+      $ref: './schemas/v1/agent/agent-project-flow-edge-dto.yml#/AgentProjectFlowEdgeDTO'
+    AgentProjectFlowPaletteItemDTO:
+      $ref: './schemas/v1/agent/agent-project-flow-palette-item-dto.yml#/AgentProjectFlowPaletteItemDTO'
+    AgentProjectFlowPaletteResponseDTO:
+      $ref: './schemas/v1/agent/agent-project-flow-palette-response-dto.yml#/AgentProjectFlowPaletteResponseDTO'
     ProjectAgentResponseDTO:
       $ref: './schemas/v1/agent/project-agent-response-dto.yml#/ProjectAgentResponseDTO'
     ProjectAgentsResponseDTO:

--- a/apis/bffssox/rest/paths/v1/agent-projects-flow-palette.yml
+++ b/apis/bffssox/rest/paths/v1/agent-projects-flow-palette.yml
@@ -1,0 +1,32 @@
+get:
+  tags:
+    - AgentProject
+  operationId: getAgentProjectFlowPalette
+  summary: Get automation project flow palette
+  description: >
+    Returns automation project flow palette for the authenticated user.
+    Returns 404 when project is missing, deleted, or not owned by the current user.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: projectId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    "200":
+      description: Agent project flow palette
+      content:
+        application/json:
+          schema:
+            $ref: "../../openapi.yml#/components/schemas/AgentProjectFlowPaletteResponseDTO"
+    "400":
+      $ref: "../../openapi.yml#/components/responses/BadRequest"
+    "401":
+      $ref: "../../openapi.yml#/components/responses/Unauthorized"
+    "404":
+      $ref: "../../openapi.yml#/components/responses/NotFound"
+    "500":
+      $ref: "../../openapi.yml#/components/responses/InternalServerError"

--- a/apis/bffssox/rest/paths/v1/agent-projects-flow.yml
+++ b/apis/bffssox/rest/paths/v1/agent-projects-flow.yml
@@ -1,0 +1,32 @@
+get:
+  tags:
+    - AgentProject
+  operationId: getAgentProjectFlow
+  summary: Get automation project flow graph
+  description: >
+    Returns automation project flow graph for the authenticated user.
+    Returns 404 when project is missing, deleted, or not owned by the current user.
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: projectId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    "200":
+      description: Agent project flow graph
+      content:
+        application/json:
+          schema:
+            $ref: "../../openapi.yml#/components/schemas/AgentProjectFlowDTO"
+    "400":
+      $ref: "../../openapi.yml#/components/responses/BadRequest"
+    "401":
+      $ref: "../../openapi.yml#/components/responses/Unauthorized"
+    "404":
+      $ref: "../../openapi.yml#/components/responses/NotFound"
+    "500":
+      $ref: "../../openapi.yml#/components/responses/InternalServerError"

--- a/apis/bffssox/rest/paths/v1/agent-projects-flow.yml
+++ b/apis/bffssox/rest/paths/v1/agent-projects-flow.yml
@@ -21,7 +21,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: "../../openapi.yml#/components/schemas/AgentProjectFlowDTO"
+            $ref: "../../openapi.yml#/components/schemas/AgentProjectFlowResponseDTO"
     "400":
       $ref: "../../openapi.yml#/components/responses/BadRequest"
     "401":

--- a/apis/bffssox/rest/schemas/v1/agent/agent-project-flow-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agent-project-flow-dto.yml
@@ -1,0 +1,28 @@
+AgentProjectFlowDTO:
+  title: AgentProjectFlowDTO
+  type: object
+  additionalProperties: false
+  required:
+    - projectId
+    - nodes
+    - edges
+  properties:
+    projectId:
+      type: string
+      format: uuid
+      description: Agent project identifier.
+    flowId:
+      type: string
+      format: uuid
+      nullable: true
+      description: Flow identifier or null when no persisted flow exists.
+    nodes:
+      type: array
+      description: Persisted flow nodes.
+      items:
+        $ref: ./agent-project-flow-node-dto.yml#/AgentProjectFlowNodeDTO
+    edges:
+      type: array
+      description: Persisted flow edges.
+      items:
+        $ref: ./agent-project-flow-edge-dto.yml#/AgentProjectFlowEdgeDTO

--- a/apis/bffssox/rest/schemas/v1/agent/agent-project-flow-edge-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agent-project-flow-edge-dto.yml
@@ -1,0 +1,25 @@
+AgentProjectFlowEdgeDTO:
+  title: AgentProjectFlowEdgeDTO
+  type: object
+  additionalProperties: false
+  required:
+    - source
+    - target
+    - edgeType
+    - configJson
+  properties:
+    source:
+      type: string
+      format: uuid
+      description: Source node reference identifier.
+    target:
+      type: string
+      format: uuid
+      description: Target node reference identifier.
+    edgeType:
+      type: string
+      description: Flow edge type.
+    configJson:
+      type: object
+      additionalProperties: true
+      description: Raw edge configuration payload.

--- a/apis/bffssox/rest/schemas/v1/agent/agent-project-flow-node-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agent-project-flow-node-dto.yml
@@ -1,0 +1,33 @@
+AgentProjectFlowNodeDTO:
+  title: AgentProjectFlowNodeDTO
+  type: object
+  additionalProperties: false
+  required:
+    - nodeType
+    - referenceId
+    - label
+    - designStatus
+    - configJson
+  properties:
+    nodeType:
+      type: string
+      description: Flow node type.
+    referenceId:
+      type: string
+      format: uuid
+      description: Node reference identifier.
+    label:
+      type: string
+      description: Node label.
+    position:
+      type: object
+      nullable: true
+      additionalProperties: true
+      description: Optional node position payload.
+    designStatus:
+      type: string
+      description: Node design status.
+    configJson:
+      type: object
+      additionalProperties: true
+      description: Raw node configuration payload.

--- a/apis/bffssox/rest/schemas/v1/agent/agent-project-flow-palette-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agent-project-flow-palette-dto.yml
@@ -1,0 +1,12 @@
+AgentProjectFlowPaletteDTO:
+  title: AgentProjectFlowPaletteDTO
+  type: object
+  additionalProperties: false
+  required:
+    - items
+  properties:
+    items:
+      type: array
+      description: Palette items containing one USER source and project-attached visible AGENT sources.
+      items:
+        $ref: ./agent-project-flow-palette-item-dto.yml#/AgentProjectFlowPaletteItemDTO

--- a/apis/bffssox/rest/schemas/v1/agent/agent-project-flow-palette-item-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agent-project-flow-palette-item-dto.yml
@@ -1,0 +1,5 @@
+AgentProjectFlowPaletteItemDTO:
+  title: AgentProjectFlowPaletteItemDTO
+  type: object
+  additionalProperties: true
+  description: Flow palette item payload.

--- a/apis/bffssox/rest/schemas/v1/agent/agent-project-flow-palette-response-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agent-project-flow-palette-response-dto.yml
@@ -3,16 +3,7 @@ AgentProjectFlowPaletteResponseDTO:
   type: object
   additionalProperties: false
   required:
-    - userSources
-    - agents
+    - palette
   properties:
-    userSources:
-      type: array
-      description: Palette USER source item collection.
-      items:
-        $ref: ./agent-project-flow-palette-item-dto.yml#/AgentProjectFlowPaletteItemDTO
-    agents:
-      type: array
-      description: Palette AGENT items attached to the project.
-      items:
-        $ref: ./agent-project-flow-palette-item-dto.yml#/AgentProjectFlowPaletteItemDTO
+    palette:
+      $ref: ./agent-project-flow-palette-dto.yml#/AgentProjectFlowPaletteDTO

--- a/apis/bffssox/rest/schemas/v1/agent/agent-project-flow-palette-response-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agent-project-flow-palette-response-dto.yml
@@ -1,0 +1,18 @@
+AgentProjectFlowPaletteResponseDTO:
+  title: AgentProjectFlowPaletteResponseDTO
+  type: object
+  additionalProperties: false
+  required:
+    - userSources
+    - agents
+  properties:
+    userSources:
+      type: array
+      description: Palette USER source item collection.
+      items:
+        $ref: ./agent-project-flow-palette-item-dto.yml#/AgentProjectFlowPaletteItemDTO
+    agents:
+      type: array
+      description: Palette AGENT items attached to the project.
+      items:
+        $ref: ./agent-project-flow-palette-item-dto.yml#/AgentProjectFlowPaletteItemDTO

--- a/apis/bffssox/rest/schemas/v1/agent/agent-project-flow-response-dto.yml
+++ b/apis/bffssox/rest/schemas/v1/agent/agent-project-flow-response-dto.yml
@@ -1,0 +1,9 @@
+AgentProjectFlowResponseDTO:
+  title: AgentProjectFlowResponseDTO
+  type: object
+  additionalProperties: false
+  required:
+    - flow
+  properties:
+    flow:
+      $ref: ./agent-project-flow-dto.yml#/AgentProjectFlowDTO

--- a/apis/fgaisox/rest/metadata.yml
+++ b/apis/fgaisox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.16
+  version: 0.0.17
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/fgaisox/rest/metadata.yml
+++ b/apis/fgaisox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.17
+  version: 0.0.18
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Forge AI Service Sitionix
   description: API specification for Forge AI service
-  version: 0.0.17
+  version: 0.0.18
   contact:
     name: APP Sitionix
 servers:

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Forge AI Service Sitionix
   description: API specification for Forge AI service
-  version: 0.0.16
+  version: 0.0.17
   contact:
     name: APP Sitionix
 servers:
@@ -79,6 +79,10 @@ components:
       $ref: './schemas/v1/forgeai/api-lane-contract-result.yml#/ApiLaneContractResult'
     ApiLaneGeneratedArtifact:
       $ref: './schemas/v1/forgeai/api-lane-generated-artifact.yml#/ApiLaneGeneratedArtifact'
+    ApiLaneEvidence:
+      $ref: './schemas/v1/forgeai/api-lane-evidence.yml#/ApiLaneEvidence'
+    ApiLaneDependencyEvidence:
+      $ref: './schemas/v1/forgeai/api-lane-dependency-evidence.yml#/ApiLaneDependencyEvidence'
     CompleteApiLaneResponse:
       $ref: './schemas/v1/forgeai/complete-api-lane-response.yml#/CompleteApiLaneResponse'
     CompleteImplementBeLaneRequestDTO:

--- a/apis/fgaisox/rest/schemas/v1/forgeai/api-lane-dependency-evidence.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/api-lane-dependency-evidence.yml
@@ -1,0 +1,17 @@
+ApiLaneDependencyEvidence:
+  type: object
+  required:
+    - scope
+    - runId
+  properties:
+    scope:
+      type: string
+      minLength: 1
+      description: Scope for which generation evidence is provided.
+      example: backendforfrontendservice-sox
+    runId:
+      type: integer
+      format: int64
+      minimum: 1
+      description: GitHub Actions workflow run identifier that generated required dependency artifacts.
+      example: 26088670378

--- a/apis/fgaisox/rest/schemas/v1/forgeai/api-lane-evidence.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/api-lane-evidence.yml
@@ -1,0 +1,16 @@
+ApiLaneEvidence:
+  type: object
+  required:
+    - prUrl
+    - dependencies
+  properties:
+    prUrl:
+      type: string
+      minLength: 1
+      description: Pull request URL for the API contract unit where generation was executed.
+      example: https://github.com/sitionix/app-afesox/pull/143
+    dependencies:
+      type: array
+      description: Generation evidence entries by scope. Extra entries are allowed, but required scopes must be present.
+      items:
+        $ref: './api-lane-dependency-evidence.yml#/ApiLaneDependencyEvidence'

--- a/apis/fgaisox/rest/schemas/v1/forgeai/api-lane-evidence.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/api-lane-evidence.yml
@@ -2,6 +2,7 @@ ApiLaneEvidence:
   type: object
   required:
     - prUrl
+    - repo
     - dependencies
   properties:
     prUrl:
@@ -9,6 +10,11 @@ ApiLaneEvidence:
       minLength: 1
       description: Pull request URL for the API contract unit where generation was executed.
       example: https://github.com/sitionix/app-afesox/pull/143
+    repo:
+      type: string
+      minLength: 1
+      description: GitHub repository in owner/repo format where evidence workflow runs were executed.
+      example: sitionix/app-afesox
     dependencies:
       type: array
       description: Generation evidence entries by scope. Extra entries are allowed, but required scopes must be present.

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-api-lane-request.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-api-lane-request.yml
@@ -3,6 +3,7 @@ CompleteApiLaneRequest:
   required:
     - summary
     - contracts
+    - evidence
     - notes
   properties:
     summary:
@@ -15,6 +16,8 @@ CompleteApiLaneRequest:
       description: List of generated or updated contract results. Each item groups operation metadata with the generated artifacts needed by downstream implementers.
       items:
         $ref: './api-lane-contract-result.yml#/ApiLaneContractResult'
+    evidence:
+      $ref: './api-lane-evidence.yml#/ApiLaneEvidence'
     notes:
       type: array
       description: Additional API-lane level notes that apply to all contract results.


### PR DESCRIPTION
## Summary
- add required `evidence.repo` field to API lane completion contract
- bump fgaisox REST version from 0.0.17 to 0.0.18

## Why
- lane evidence validation must verify run existence against explicit repository instead of inferring from PR URL

## Notes
- contract-only change in app-afesox