### PR TITLE
[SITIONIX-142] Flatten completeApiLane evidence fields to top-level

### DIFF
--- a/apis/fgaisox/rest/metadata.yml
+++ b/apis/fgaisox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.16
+  version: 0.0.19
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -2,7 +2,8 @@ openapi: "3.0.0"
 info:
   title: API Forge AI Service Sitionix
   description: API specification for Forge AI service
-  version: 0.0.16
+  version: 0.0.19
+  version: 0.0.19
   contact:
     name: APP Sitionix
 servers:

--- a/apis/fgaisox/rest/schemas/v1/forgeai/complete-api-lane-request.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/complete-api-lane-request.yml
@@ -3,6 +3,9 @@ CompleteApiLaneRequest:
   required:
     - summary
     - contracts
+    - prUrl
+    - repo
+    - dependencies
     - notes
   properties:
     summary:
@@ -15,6 +18,21 @@ CompleteApiLaneRequest:
       description: List of generated or updated contract results. Each item groups operation metadata with the generated artifacts needed by downstream implementers.
       items:
         $ref: './api-lane-contract-result.yml#/ApiLaneContractResult'
+    prUrl:
+      type: string
+      minLength: 1
+      description: Pull request URL for the API contract unit where generation was executed.
+      example: https://github.com/sitionix/app-afesox/pull/143
+    repo:
+      type: string
+      minLength: 1
+      description: GitHub repository in owner/repo format where evidence workflow runs were executed.
+      example: sitionix/app-afesox
+    dependencies:
+      type: array
+      description: Generation evidence entries by scope. Extra entries are allowed, but required scopes must be present.
+      items:
+        $ref: './api-lane-dependency-evidence.yml#/ApiLaneDependencyEvidence'
     notes:
       type: array
       description: Additional API-lane level notes that apply to all contract results.


### PR DESCRIPTION
## Summary
- move API lane completion evidence fields to top-level request
- add required top-level fields: prUrl, repo, dependencies
- keep change scoped strictly to fgaisox contract files
- bump fgaisox version to 0.0.19 in both openapi and metadata

## Scope
- service: app-afesox only
- files changed only under apis/fgaisox/rest
