### PR TITLE
[SITIONIX-142] - Add Forge AI operator API-first contracts

### DIFF
--- a/apis/fgaisox/rest/metadata.yml
+++ b/apis/fgaisox/rest/metadata.yml
@@ -1,5 +1,5 @@
 api:
-  version: 0.0.17
+  version: 0.0.18
   visibility: PUBLIC
   metadata:
     version: "1.0"

--- a/apis/fgaisox/rest/openapi.yml
+++ b/apis/fgaisox/rest/openapi.yml
@@ -2,7 +2,7 @@ openapi: "3.0.0"
 info:
   title: API Forge AI Service Sitionix
   description: API specification for Forge AI service
-  version: 0.0.17
+  version: 0.0.18
   contact:
     name: APP Sitionix
 servers:
@@ -10,9 +10,29 @@ servers:
     url: 'http://localhost:9099/fgaisox'
 tags:
   - name: ForgeAI
+  - name: ForgeAiOperatorExecution
+  - name: ForgeAiOperatorTicket
 paths:
   /api/v1/forge-ai/start:
     $ref: './paths/v1/forge-ai-start.yml'
+  /api/v1/forge-ai/operator/executions:
+    $ref: './paths/v1/forge-ai-operator-executions.yml'
+  /api/v1/forge-ai/operator/executions/active:
+    $ref: './paths/v1/forge-ai-operator-executions-active.yml'
+  /api/v1/forge-ai/operator/executions/{executionId}:
+    $ref: './paths/v1/forge-ai-operator-executions-by-id.yml'
+  /api/v1/forge-ai/operator/executions/{executionId}/interrupt:
+    $ref: './paths/v1/forge-ai-operator-executions-interrupt.yml'
+  /api/v1/forge-ai/operator/tickets/active:
+    $ref: './paths/v1/forge-ai-operator-tickets-active.yml'
+  /api/v1/forge-ai/operator/tickets/{ticketId}:
+    $ref: './paths/v1/forge-ai-operator-tickets-by-id.yml'
+  /api/v1/forge-ai/operator/tickets/{ticketId}/stream:
+    $ref: './paths/v1/forge-ai-operator-tickets-stream.yml'
+  /api/v1/forge-ai/operator/tickets/{ticketId}/watchers/{watcherId}/heartbeat:
+    $ref: './paths/v1/forge-ai-operator-tickets-watchers-heartbeat.yml'
+  /api/v1/forge-ai/operator/tickets/{ticketId}/interrupt:
+    $ref: './paths/v1/forge-ai-operator-tickets-interrupt.yml'
   /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/analyzer/complete:
     $ref: './paths/v1/forge-ai-complete-analyzer-lane.yml'
   /api/v1/forge-ai/tickets/{ticketId}/lanes/{laneId}/architect/complete:
@@ -45,6 +65,22 @@ components:
       $ref: './schemas/v1/forgeai/start-forge-request-dto.yml#/StartForgeRequestDTO'
     StartForgeResponseDTO:
       $ref: './schemas/v1/forgeai/start-forge-response-dto.yml#/StartForgeResponseDTO'
+    OperatorExecutionDTO:
+      $ref: './schemas/v1/forgeai/operator-execution-dto.yml#/OperatorExecutionDTO'
+    OperatorExecutionsResponseDTO:
+      $ref: './schemas/v1/forgeai/operator-executions-response-dto.yml#/OperatorExecutionsResponseDTO'
+    TicketOperatorRunDTO:
+      $ref: './schemas/v1/forgeai/ticket-operator-run-dto.yml#/TicketOperatorRunDTO'
+    TicketOperatorRunsResponseDTO:
+      $ref: './schemas/v1/forgeai/ticket-operator-runs-response-dto.yml#/TicketOperatorRunsResponseDTO'
+    TicketOperatorEventDTO:
+      $ref: './schemas/v1/forgeai/ticket-operator-event-dto.yml#/TicketOperatorEventDTO'
+    TicketOperatorExecutionDTO:
+      $ref: './schemas/v1/forgeai/ticket-operator-execution-dto.yml#/TicketOperatorExecutionDTO'
+    TicketOperatorLaneSummaryDTO:
+      $ref: './schemas/v1/forgeai/ticket-operator-lane-summary-dto.yml#/TicketOperatorLaneSummaryDTO'
+    TicketOperatorSnapshotResponseDTO:
+      $ref: './schemas/v1/forgeai/ticket-operator-snapshot-response-dto.yml#/TicketOperatorSnapshotResponseDTO'
     CompleteAnalyzerLaneRequestDTO:
       $ref: './schemas/v1/forgeai/complete-analyzer-lane-request-dto.yml#/CompleteAnalyzerLaneRequestDTO'
     AnalyzerArchitectHandoffDTO:

--- a/apis/fgaisox/rest/paths/v1/forge-ai-operator-executions-active.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-operator-executions-active.yml
@@ -1,0 +1,14 @@
+get:
+  tags:
+    - ForgeAiOperatorExecution
+  summary: Get active Forge AI executions alias
+  operationId: getActiveOperatorExecutions
+  responses:
+    '200':
+      description: Active executions
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/OperatorExecutionsResponseDTO'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/fgaisox/rest/paths/v1/forge-ai-operator-executions-by-id.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-operator-executions-by-id.yml
@@ -1,0 +1,23 @@
+get:
+  tags:
+    - ForgeAiOperatorExecution
+  summary: Get one Forge AI execution
+  operationId: getOperatorExecution
+  parameters:
+    - in: path
+      name: executionId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    '200':
+      description: Execution
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/OperatorExecutionDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/fgaisox/rest/paths/v1/forge-ai-operator-executions-interrupt.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-operator-executions-interrupt.yml
@@ -1,0 +1,23 @@
+post:
+  tags:
+    - ForgeAiOperatorExecution
+  summary: Interrupt one Forge AI execution
+  operationId: interruptOperatorExecution
+  parameters:
+    - in: path
+      name: executionId
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    '200':
+      description: Interrupted execution
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/OperatorExecutionDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/fgaisox/rest/paths/v1/forge-ai-operator-executions.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-operator-executions.yml
@@ -1,0 +1,14 @@
+get:
+  tags:
+    - ForgeAiOperatorExecution
+  summary: Get active Forge AI executions
+  operationId: getOperatorExecutions
+  responses:
+    '200':
+      description: Active executions
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/OperatorExecutionsResponseDTO'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/fgaisox/rest/paths/v1/forge-ai-operator-tickets-active.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-operator-tickets-active.yml
@@ -1,0 +1,14 @@
+get:
+  tags:
+    - ForgeAiOperatorTicket
+  summary: Get active Forge AI operator tickets
+  operationId: getActiveOperatorTickets
+  responses:
+    '200':
+      description: Active ticket operator runs
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/TicketOperatorRunsResponseDTO'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/fgaisox/rest/paths/v1/forge-ai-operator-tickets-by-id.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-operator-tickets-by-id.yml
@@ -1,0 +1,29 @@
+get:
+  tags:
+    - ForgeAiOperatorTicket
+  summary: Get one Forge AI operator ticket snapshot
+  operationId: getOperatorTicket
+  parameters:
+    - in: path
+      name: ticketId
+      required: true
+      schema:
+        type: string
+        format: uuid
+    - in: query
+      name: verbosity
+      required: false
+      schema:
+        type: string
+        default: minimal
+  responses:
+    '200':
+      description: Ticket operator snapshot
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/TicketOperatorSnapshotResponseDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/fgaisox/rest/paths/v1/forge-ai-operator-tickets-interrupt.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-operator-tickets-interrupt.yml
@@ -1,0 +1,29 @@
+post:
+  tags:
+    - ForgeAiOperatorTicket
+  summary: Interrupt one Forge AI ticket
+  operationId: interruptOperatorTicket
+  parameters:
+    - in: path
+      name: ticketId
+      required: true
+      schema:
+        type: string
+        format: uuid
+    - in: query
+      name: reason
+      required: false
+      schema:
+        type: string
+        default: OPERATOR_TICKET_INTERRUPT
+  responses:
+    '200':
+      description: Updated ticket operator run
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/TicketOperatorRunDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/fgaisox/rest/paths/v1/forge-ai-operator-tickets-stream.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-operator-tickets-stream.yml
@@ -1,0 +1,47 @@
+get:
+  tags:
+    - ForgeAiOperatorTicket
+  summary: Stream ticket operator events
+  operationId: streamOperatorTicket
+  parameters:
+    - in: path
+      name: ticketId
+      required: true
+      schema:
+        type: string
+        format: uuid
+    - in: query
+      name: watcherId
+      required: true
+      schema:
+        type: string
+    - in: query
+      name: verbosity
+      required: false
+      schema:
+        type: string
+        default: minimal
+    - in: query
+      name: stopOnWindowClose
+      required: false
+      schema:
+        type: boolean
+        default: true
+    - in: query
+      name: replay
+      required: false
+      schema:
+        type: boolean
+        default: true
+  responses:
+    '200':
+      description: Ticket operator event stream
+      content:
+        application/x-ndjson:
+          schema:
+            type: string
+            format: binary
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/fgaisox/rest/paths/v1/forge-ai-operator-tickets-watchers-heartbeat.yml
+++ b/apis/fgaisox/rest/paths/v1/forge-ai-operator-tickets-watchers-heartbeat.yml
@@ -1,0 +1,28 @@
+post:
+  tags:
+    - ForgeAiOperatorTicket
+  summary: Heartbeat ticket watcher
+  operationId: heartbeatOperatorTicketWatcher
+  parameters:
+    - in: path
+      name: ticketId
+      required: true
+      schema:
+        type: string
+        format: uuid
+    - in: path
+      name: watcherId
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: Updated ticket operator run
+      content:
+        application/json:
+          schema:
+            $ref: '../../openapi.yml#/components/schemas/TicketOperatorRunDTO'
+    '400':
+      $ref: '../../openapi.yml#/components/responses/BadRequest'
+    '500':
+      $ref: '../../openapi.yml#/components/responses/InternalServerError'

--- a/apis/fgaisox/rest/schemas/v1/forgeai/operator-execution-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/operator-execution-dto.yml
@@ -1,0 +1,45 @@
+OperatorExecutionDTO:
+  type: object
+  properties:
+    executionId:
+      type: string
+      format: uuid
+    ticketId:
+      type: string
+      format: uuid
+    laneId:
+      type: string
+      format: uuid
+    agentId:
+      type: string
+    scope:
+      type: string
+    status:
+      type: string
+    processPid:
+      type: integer
+      format: int64
+    codexSessionId:
+      type: string
+    codexThreadId:
+      type: string
+    activeTurnId:
+      type: string
+    activeStepId:
+      type: string
+    activeStepOrder:
+      type: integer
+      format: int32
+    activeStepTitle:
+      type: string
+    lastProgressEvent:
+      type: string
+    lastProgressAt:
+      type: string
+      format: date-time
+    stopCommand:
+      type: string
+    stderrTail:
+      type: array
+      items:
+        type: string

--- a/apis/fgaisox/rest/schemas/v1/forgeai/operator-executions-response-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/operator-executions-response-dto.yml
@@ -1,0 +1,7 @@
+OperatorExecutionsResponseDTO:
+  type: object
+  properties:
+    items:
+      type: array
+      items:
+        $ref: '../../../openapi.yml#/components/schemas/OperatorExecutionDTO'

--- a/apis/fgaisox/rest/schemas/v1/forgeai/ticket-operator-event-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/ticket-operator-event-dto.yml
@@ -1,0 +1,42 @@
+TicketOperatorEventDTO:
+  type: object
+  properties:
+    ticketId:
+      type: string
+      format: uuid
+    laneId:
+      type: string
+      format: uuid
+    executionId:
+      type: string
+      format: uuid
+    agentId:
+      type: string
+    scope:
+      type: string
+    stepId:
+      type: string
+    stepTitle:
+      type: string
+    stepOrder:
+      type: integer
+      format: int32
+    totalSteps:
+      type: integer
+      format: int32
+    codexProcessPid:
+      type: integer
+      format: int64
+    codexSessionId:
+      type: string
+    codexThreadId:
+      type: string
+    activeTurnId:
+      type: string
+    eventType:
+      type: string
+    message:
+      type: string
+    timestamp:
+      type: string
+      format: date-time

--- a/apis/fgaisox/rest/schemas/v1/forgeai/ticket-operator-execution-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/ticket-operator-execution-dto.yml
@@ -1,0 +1,31 @@
+TicketOperatorExecutionDTO:
+  type: object
+  properties:
+    executionId:
+      type: string
+      format: uuid
+    laneId:
+      type: string
+      format: uuid
+    agentId:
+      type: string
+    scope:
+      type: string
+    status:
+      type: string
+    processPid:
+      type: integer
+      format: int64
+    codexSessionId:
+      type: string
+    codexThreadId:
+      type: string
+    activeTurnId:
+      type: string
+    activeStepId:
+      type: string
+    activeStepOrder:
+      type: integer
+      format: int32
+    activeStepTitle:
+      type: string

--- a/apis/fgaisox/rest/schemas/v1/forgeai/ticket-operator-lane-summary-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/ticket-operator-lane-summary-dto.yml
@@ -1,0 +1,18 @@
+TicketOperatorLaneSummaryDTO:
+  type: object
+  properties:
+    completed:
+      type: integer
+      format: int64
+    inProgress:
+      type: integer
+      format: int64
+    ready:
+      type: integer
+      format: int64
+    notStarted:
+      type: integer
+      format: int64
+    notNeeded:
+      type: integer
+      format: int64

--- a/apis/fgaisox/rest/schemas/v1/forgeai/ticket-operator-run-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/ticket-operator-run-dto.yml
@@ -1,0 +1,38 @@
+TicketOperatorRunDTO:
+  type: object
+  properties:
+    ticketId:
+      type: string
+      format: uuid
+    ticketKey:
+      type: string
+    status:
+      type: string
+    watcherId:
+      type: string
+    lastHeartbeatAt:
+      type: string
+      format: date-time
+    cancelRequestedAt:
+      type: string
+      format: date-time
+    cancelledAt:
+      type: string
+      format: date-time
+    interruptReason:
+      type: string
+    activeExecutionIds:
+      type: array
+      items:
+        type: string
+        format: uuid
+    activeLaneIds:
+      type: array
+      items:
+        type: string
+        format: uuid
+    lastProgressEvent:
+      type: string
+    lastProgressAt:
+      type: string
+      format: date-time

--- a/apis/fgaisox/rest/schemas/v1/forgeai/ticket-operator-runs-response-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/ticket-operator-runs-response-dto.yml
@@ -1,0 +1,7 @@
+TicketOperatorRunsResponseDTO:
+  type: object
+  properties:
+    items:
+      type: array
+      items:
+        $ref: '../../../openapi.yml#/components/schemas/TicketOperatorRunDTO'

--- a/apis/fgaisox/rest/schemas/v1/forgeai/ticket-operator-snapshot-response-dto.yml
+++ b/apis/fgaisox/rest/schemas/v1/forgeai/ticket-operator-snapshot-response-dto.yml
@@ -1,0 +1,15 @@
+TicketOperatorSnapshotResponseDTO:
+  type: object
+  properties:
+    run:
+      $ref: '../../../openapi.yml#/components/schemas/TicketOperatorRunDTO'
+    laneSummary:
+      $ref: '../../../openapi.yml#/components/schemas/TicketOperatorLaneSummaryDTO'
+    activeExecutions:
+      type: array
+      items:
+        $ref: '../../../openapi.yml#/components/schemas/TicketOperatorExecutionDTO'
+    recentEvents:
+      type: array
+      items:
+        $ref: '../../../openapi.yml#/components/schemas/TicketOperatorEventDTO'


### PR DESCRIPTION
## Summary
- add Forge AI operator execution and ticket API-first contract surface in fgaisox
- bump fgaisox REST contract version to 0.0.18
- keep the contract unit scoped to fgaisox source-of-truth only

## Notes
- created from clean develop after pull
- excludes unrelated atmssox and bffssox local work
